### PR TITLE
feat(Pagination): allow custom content n for first, prev, next, last btn

### DIFF
--- a/packages/pagination/src/VPagination.stories.ts
+++ b/packages/pagination/src/VPagination.stories.ts
@@ -4,7 +4,12 @@ import VPagination from './VPagination.vue';
 export default {
   title: 'Components/Pagination',
   component: VPagination,
-  argTypes: {},
+  argTypes: {
+    btnLast: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+    btnFirst: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+    btnNext: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+    btnPrev: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+  },
   args: {
     totalItems: 30,
     itemsPerPage: 10,
@@ -18,20 +23,21 @@ export default {
     siblingCount: 1,
     boundaryCount: 1,
     simple: false,
+    btnLast: ''
   },
 } as Meta;
 
 const Template: Story = (args) => ({
   // Components used in your story `template` are defined in the `components` object
   components: {
-    'V-component': VPagination,
+    'v-pagination': VPagination,
   },
   // The story's `args` need to be mapped into the template through the `setup()` method
   setup() {
     return {args};
   },
   // And then the `args` are bound to your component with `v-bind="args"`
-  template: `<V-component v-bind="args">{{ args.label }}</V-component>`,
+  template: `<v-pagination v-bind="args" data-test="fasdasd">{{ args.label }}<template v-slot:btnLast><footer v-if="args.btnLast" v-html="args.btnLast" /></template></v-pagination>`,
 });
 
 export const Default = Template.bind({});

--- a/packages/pagination/src/VPagination.vue
+++ b/packages/pagination/src/VPagination.vue
@@ -139,6 +139,7 @@ watch(
         }"
         @click.prevent="pagino.previous()"
       >
+        <slot name="btnPrev">
         <span class="sr-only">Previous</span>
         <!-- Heroicon name: solid/chevron-left -->
         <svg
@@ -154,6 +155,7 @@ watch(
             clip-rule="evenodd"
           />
         </svg>
+        </slot>
       </button>
 
       <button
@@ -177,6 +179,7 @@ watch(
         }"
         @click.prevent="pagino.next()"
       >
+        <slot name="btnNext">
         <span class="sr-only">Next</span>
         <!-- Heroicon name: solid/chevron-right -->
         <svg
@@ -192,6 +195,7 @@ watch(
             clip-rule="evenodd"
           />
         </svg>
+        </slot>
       </button>
       <button
         v-else-if="item === 'first'"
@@ -214,6 +218,7 @@ watch(
         }"
         @click.prevent="pagino.first()"
       >
+        <slot name="btnFirst">
         <span class="sr-only">First</span>
         <svg
           class="h-4 w-4"
@@ -227,6 +232,7 @@ watch(
             clip-rule="evenodd"
           />
         </svg>
+        </slot>
       </button>
       <button
         v-else-if="item === 'last'"
@@ -249,24 +255,26 @@ watch(
         }"
         @click.prevent="pagino.last()"
       >
-        <span class="sr-only">Last</span>
-        <svg
-          class="h-4 w-4"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 20 20"
-          fill="currentColor"
-        >
-          <path
-            fill-rule="evenodd"
-            d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z"
-            clip-rule="evenodd"
-          />
-          <path
-            fill-rule="evenodd"
-            d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z"
-            clip-rule="evenodd"
-          />
-        </svg>
+        <slot name="btnLast">
+          <span class="sr-only">Last</span>
+          <svg
+              class="h-4 w-4"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+          >
+            <path
+                fill-rule="evenodd"
+                d="M10.293 15.707a1 1 0 010-1.414L14.586 10l-4.293-4.293a1 1 0 111.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+            />
+            <path
+                fill-rule="evenodd"
+                d="M4.293 15.707a1 1 0 010-1.414L8.586 10 4.293 5.707a1 1 0 011.414-1.414l5 5a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0z"
+                clip-rule="evenodd"
+            />
+          </svg>
+        </slot>
       </button>
       <span
         v-else-if="item === 'start-ellipsis' || item === 'end-ellipsis'"


### PR DESCRIPTION
This allow users to customize contents for "First", "Last", "Previous" and "Next" button using `slots`, with fallback to default implementation of "<<", ">>", "<" and ">" respectively. 

usage will be something like this:
```
<pagination>
    <template v:slot="btnFirst">First</template> // to customize "first" button content. Defaults to "<<"
    <template v:slot="btnLast">Last</template> // to customize "last" button content. Defaults to ">>"
    <template v:slot="btnPrev">Previous</template> // to customize "previous" button content. Defaults to "<"
    <template v:slot="btnNext">Next</template> // to customize "next" button content. Defaults to ">"
</pagination>
```