### PR TITLE
support pagination slots

### DIFF
--- a/packages/table/src/VDataTablePagination.stories.ts
+++ b/packages/table/src/VDataTablePagination.stories.ts
@@ -1,6 +1,6 @@
 import VDataTablePagination from './VDataTablePagination.vue';
 import {themeColors} from '@gits-id/utils/colors';
-import {Meta, Story} from '@storybook/vue3';
+import {Args, Meta, Story} from '@storybook/vue3';
 
 export default {
   title: 'Components/DataTablePagination',
@@ -9,6 +9,10 @@ export default {
     color: {
       control: {type: 'select', options: themeColors},
     },
+      btnLast: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+      btnFirst: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+      btnNext: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
+      btnPrev: { control: { type: 'text' }, defaultValue: '', table: { category: 'Slots'} },
   },
   args: {
     totalItems: 30,
@@ -25,9 +29,25 @@ const Template: Story = (args) => ({
     VDataTablePagination,
   },
   setup() {
-    return {args};
+    const {btnLast, btnFirst, btnNext, btnPrev} = args;
+
+    const argsWSlots:Args = {
+      args: args,
+      $slots: {}
+    };
+
+    // added `$slot` prop to `args` so we can easily access it in storybook template
+    for (const [key, value] of Object.entries({btnPrev, btnNext, btnFirst, btnLast})) {
+      if(value !== undefined && value !== null && value !== ""){
+        argsWSlots.$slots[key] = value;
+      }
+    }
+
+    return {args:argsWSlots};
   },
-  template: `<v-data-table-pagination v-bind="args" />`,
+  template: `<v-data-table-pagination v-bind="args.args">
+  <template v-for="(content, name) in args.$slots" v-slot:[name]>{{content}}</template>
+  </v-data-table-pagination>`,
 });
 
 export const Default = Template.bind({});

--- a/packages/table/src/VDataTablePagination.vue
+++ b/packages/table/src/VDataTablePagination.vue
@@ -166,7 +166,9 @@ watch(
         :total-items="totalItems"
         :items-per-page="itemsPerPage"
         v-bind="pagination"
-      />
+      >
+        <template v-for="(_, name) in $slots" v-slot:[name]><slot :name="name" /></template>
+      </Pagination>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This allows users to pass `VPagination` slots into `VDataTablePagination` component, enabling user to further customize the component without whipping up their own custom component to make this work.

I've also updated the storybook docs to reflect these changes.

Usage will be something like this:
```
<VDataTablePagination>
     <template v:slot="btnFirst">First</template> // to customize "first" button content. Defaults to "<<"
    <template v:slot="btnLast">Last</template> // to customize "last" button content. Defaults to ">>"
    <template v:slot="btnPrev">Previous</template> // to customize "previous" button content. Defaults to "<"
    <template v:slot="btnNext">Next</template> // to customize "next" button content. Defaults to ">"
</VDataTablePagination>
```