### PR TITLE
feat(card): add tailwind plugin for card component

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -35,6 +35,7 @@ export default defineConfig({
           {text: 'Alert', link: '/components/alert'},
           {text: 'AppBar', link: '/components/app-bar'},
           {text: 'Avatar', link: '/components/avatar'},
+          {text: 'Card', link: '/components/card'},
         ],
       },
     ],

--- a/docs/components/card.md
+++ b/docs/components/card.md
@@ -1,0 +1,220 @@
+# Card
+
+## Usage
+
+### Basic Usage
+
+```vue
+<template>
+  <!-- VCard is registered globally -->
+  <VCard> Hello World </VCard>
+</template>
+```
+
+::: info
+The `VCard` component is registered globally when you install with `@gits-id/ui`. So you don't need to import it manually.
+:::
+
+### With Title
+
+```vue
+<template>
+  <VCard title="Header"> Hello World </VCard>
+</template>
+```
+
+### Header and Footer
+
+```vue {2,4-6}
+<template>
+  <VCard title="Header">
+    <!-- footer slot -->
+    <template #footer>
+      <VBtn> Action </VBtn>
+    </template>
+    <!-- body -->
+    <p>Hello World</p>
+  </VCard>
+</template>
+```
+
+### Hide Header and Footer
+
+```vue {2}
+<template>
+  <VCard title="Header" hide-header hide-footer>
+    <!-- footer slot -->
+    <template #footer>
+      <VBtn> Action </VBtn>
+    </template>
+    <!-- body -->
+    <p>Hello World</p>
+  </VCard>
+</template>
+```
+
+### Colors
+
+- **prop**: `color`
+- **type**: `string`
+- **default**: `default`
+- **required**: `false`
+
+Use `color` to different color style to the card.
+
+```vue
+<template>
+  <VCard> Hello World </VCard>
+  <VCard color="primary"> Hello World </VCard>
+  <VCard color="secondary"> Hello World </VCard>
+  <VCard color="info"> Hello World </VCard>
+  <VCard color="warning"> Hello World </VCard>
+  <VCard color="success"> Hello World </VCard>
+  <VCard color="error"> Hello World </VCard>
+</template>
+```
+
+### Bordered
+
+- **prop**: `bordered`
+- **type**: `boolean`
+- **default**: `false`
+- **required**: `false`
+
+Use `bordered` to apply border to the card.
+
+```vue{6}
+<template>
+  <VCard bordered> Hello World </VCard>
+</template>
+```
+
+### Shadow
+
+- **prop**: `shadow`
+- **type**: `boolean | 'sm' | 'md' | 'lg' | 'xl' | '2xl' | 'inner' | 'none'`
+- **default**: `none`
+- **required**: `false`
+
+Use `shadow` to apply shadow style to the card.
+
+```vue
+<script setup lang="ts">
+import {ref} from 'vue';
+</script>
+
+<template>
+  <VCard shadow> Hello World </VCard>
+  <VCard shadow="sm"> Hello World </VCard>
+  <VCard shadow="md"> Hello World </VCard>
+  <VCard shadow="lg"> Hello World </VCard>
+  <VCard shadow="xl"> Hello World </VCard>
+  <VCard shadow="2xl"> Hello World </VCard>
+  <VCard shadow="inner"> Hello World </VCard>
+  <VCard shadow="none"> Hello World </VCard>
+</template>
+```
+
+## Props
+
+| Name                                            | Type                                                           | Default       |
+| ----------------------------------------------- | -------------------------------------------------------------- | ------------- |
+| [color](#color)                                 | `string` , [available colors](/guide/theme#colors)             | `default`     |
+| [shadow](#shadow)                               | `boolean`, `string`, [available shadows](/guide/theme#shadows) | `true`        |
+| [flat](#flat)                                   | `boolean`                                                      | `false`       |
+| [bordered](#bordered)                           | `boolean`                                                      | `false`       |
+| [title](#title)                                 | `string`                                                       | `false`       |
+| [flat](#flat)                                   | `boolean`                                                      | `false`       |
+| [hide-header](#hide-header)                     | `boolean`                                                      | `false`       |
+| [hide-footer](#hide-footer)                     | `boolean`                                                      | `false`       |
+| [to](#to)                                       | `string`, `RouteLocation`                                      | ` `           |
+| [default-wrapper-class](#default-wrapper-class) | `string`                                                       | ` `           |
+| [default-header-class](#default-header-class)   | `string`                                                       | `card-header` |
+| [default-body-class](#default-body-class)       | `string`                                                       | `card-body`   |
+| [default-footer-class](#default-footer-class)   | `string`                                                       | `card-footer` |
+| [wrapper-class](#wrapper-class)                 | `string`                                                       | ` `           |
+| [header-class](#header-class)                   | `string`                                                       | ` `           |
+| [footer-class](#footer-class)                   | `string`                                                       | ` `           |
+| [body-class](#body-class)                       | `string`                                                       | ` `           |
+
+## Methods
+
+None
+
+## Events
+
+None
+
+## Slots
+
+| Name                              | Props | Description                              |
+| --------------------------------- | ----- | ---------------------------------------- |
+| [default](#default)               | None  | The default Vue slot                     |
+| [header](#header)                 | None  | The card header                          |
+| [header.append](#header.append)   | None  | Slot to append before the actual header  |
+| [header.prepend](#header.prepend) | None  | Slot to prepend before the actual header |
+| [footer](#default)                | None  | The card footer                          |
+
+## CSS Variables
+
+| Variable                                        | Default Value                   |
+| ----------------------------------------------- | ------------------------------- |
+| [`--card-padding-x` ](#--card-padding-x)        | `theme('padding.4')`            |
+| [`--card-padding-y` ](#--card-padding-y)        | `theme('padding.3')`            |
+| [`--card-bg-color` ](#--card-bg-color)          | `theme('colors.white')`         |
+| [`--card-color` ](#--card-color)                | `theme('colors.gray.800')`      |
+| [`--card-border-style`](#--card-border-style)   | `solid`                         |
+| [`--card-border-width`](#--card-border-width)   | `theme('borderWidth.DEFAULT')`  |
+| [`--card-border-color`](#--card-border-color)   | `theme('borderColor.DEFAULT')`  |
+| [`--card-border-radius`](#--card-border-radius) | `theme('borderRadius.DEFAULT')` |
+
+## Customization
+
+With the power of CSS Variables and Tailwind's `theme` function, you can create your custom card.
+
+```vue{2,7-8}
+<template>
+  <VCard color="indigo"> Indigo Colored Card </VCard>
+</template>
+
+<style>
+.card-indigo {
+  --card-bg-color: theme('colors.indigo.500');
+  --card-color: theme('colors.white');
+}
+</style>
+```
+
+## Manual Installation
+
+You can also install the `Card` component individually via `@gits-id/card` package:
+
+```bash
+yarn install @gits-id/card
+```
+
+```vue
+<script setup lang="ts">
+import VCard from '@gits-id/card';
+</script>
+
+<template>
+  <VCard> Hello World </VCard>
+</template>
+```
+
+## Tailwind Plugin
+
+This package comes with custom tailwind plugin for styling. If you are installing this package separately from `@gits-id/ui` package, you need to include the plugin in `plugins` section in your Tailwind config file.
+
+```js{4}
+// tailwind.config.js
+module.exports = {
+  content: [],
+  presets: [require('@gits-id/card/plugin')],
+};
+```
+
+## Storybook
+
+View Storybook documentation [here](https://gits-ui.web.app/?path=/story/components-card--default).

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -12,11 +12,15 @@
     "gits",
     "ui-component"
   ],
-  "author": "",
-  "license": "ISC",
+  "author": "Warsono <warsono16694@gmail.com>",
+  "license": "MIT",
+  "dependencies": {
+    "vue": "^3.2.33"
+  },
   "devDependencies": {
     "@gits-id/button": "^0.11.10",
     "@gits-id/utils": "^0.11.10",
+    "@gits-id/theme": "^0.11.10",
     "@vitejs/plugin-vue": "^2.2.4",
     "@vue/test-utils": "^2.0.0-rc.17",
     "autoprefixer": "^10.4.2",
@@ -25,16 +29,23 @@
     "tailwindcss": "^3.0.23",
     "typescript": "^4.6.2",
     "vite": "^3.0.0",
-    "vitest": "^0.12.4",
-    "vue": "^3.2.31"
+    "vitest": "^0.12.4"
   },
   "main": "dist/card.umd.js",
   "unpkg": "dist/card.iife.js",
   "jsdelivr": "dist/card.iife.js",
   "module": "./dist/card.mjs",
   "types": "./dist/types/index.d.ts",
-  "gitHead": "b5a78473960cae120ca3396a242f6fb241970de4",
-  "dependencies": {
-    "vue": "^3.2.33"
-  }
+  "exports": {
+    ".": {
+      "import": "./dist/card.mjs",
+      "require": "./dist/card.js"
+    },
+    "./plugin": "./src/plugin.js",
+    "./plugin.js": "./src/plugin.js",
+    "./package.json": "./package.json",
+    "./src/*": "./src/*",
+    "./*": "./*"
+  },
+  "gitHead": "b5a78473960cae120ca3396a242f6fb241970de4"
 }

--- a/packages/card/src/VCard.stories.ts
+++ b/packages/card/src/VCard.stories.ts
@@ -1,6 +1,7 @@
 import {Meta, Story} from '@storybook/vue3';
 import VCard from './VCard.vue';
 import VBtn from '@gits-id/button';
+import {defaultColors} from '@gits-id/theme/defaultTheme';
 
 export default {
   title: 'Components/Card',
@@ -20,21 +21,19 @@ export default {
 } as Meta;
 
 const Template: Story = (args) => ({
-  // Components used in your story `template` are defined in the `components` object
   components: {VCard},
-  // The story's `args` need to be mapped into the template through the `setup()` method
   setup() {
     return {args};
   },
-  // And then the `args` are bound to your component with `v-bind="args"`
-  template: `<v-card v-bind='args'>
-  <template #header>
-    {{args.title}}
-  </template>
-  <template #footer>
-    {{args.footer}}
-  </template>
-  {{ args.body }}
+  template: `
+  <v-card v-bind='args'>
+    <template #header>
+      {{args.title}}
+    </template>
+    <template #footer>
+      {{args.footer}}
+    </template>
+    {{ args.body }}
   </v-card>`,
 });
 
@@ -88,23 +87,21 @@ BodyOnly.parameters = {
 export const Bordered = Template.bind({});
 Bordered.args = {
   bordered: true,
+  flat: true,
 };
 Bordered.parameters = {
   docs: {
     source: {
-      code: '<v-card title="Header" bordered>Body</v-card>',
+      code: '<v-card title="Header" bordered flat>Body</v-card>',
     },
   },
 };
 
 export const CustomSlots: Story = (args) => ({
-  // Components used in your story `template` are defined in the `components` object
   components: {VCard, VBtn},
-  // The story's `args` need to be mapped into the template through the `setup()` method
   setup() {
     return {args};
   },
-  // And then the `args` are bound to your component with `v-bind="args"`
   template: `
 <v-card v-bind='args' header-class="items-center" footer-class="gap-2">
   <template #header>
@@ -122,7 +119,8 @@ export const CustomSlots: Story = (args) => ({
 CustomSlots.parameters = {
   docs: {
     source: {
-      code: `<v-card header-class="items-center" footer-class="gap-2">
+      code: `
+<v-card header-class="items-center" footer-class="gap-2">
   <template #header>
     <div>My Header</div>
   </template>
@@ -148,3 +146,43 @@ Flat.parameters = {
     },
   },
 };
+
+export const Colors: Story<{}> = (args) => ({
+  components: {VCard},
+  setup() {
+    return {args, colors: ['default', ...defaultColors]};
+  },
+  template: `
+<v-card
+  v-for="(color, idx) in colors"
+  :key="idx"
+  :color="color"
+  class="mb-4"
+  hide-header
+  hide-footer
+  >
+  Card: {{ color }}
+</v-card>
+`,
+});
+
+export const Shadow: Story<{}> = (args) => ({
+  components: {VCard},
+  setup() {
+    const shadows = [true, 'sm', 'md', 'lg', 'xl', '2xl', 'inner', 'none'];
+
+    return {args, shadows};
+  },
+  template: `
+<v-card
+  v-for="(shadow, idx) in shadows"
+  :key="idx"
+  :shadow="shadow"
+  class="mb-4"
+  hide-header
+  hide-footer
+  >
+  Shadow: {{ shadow }}
+</v-card>
+`,
+});

--- a/packages/card/src/VCard.vue
+++ b/packages/card/src/VCard.vue
@@ -1,5 +1,15 @@
 <script setup lang="ts">
-import {computed, toRefs} from 'vue';
+import {computed, PropType, toRefs} from 'vue';
+
+export type CardShadow =
+  | boolean
+  | 'sm'
+  | 'md'
+  | 'lg'
+  | 'xl'
+  | '2xl'
+  | 'inner'
+  | 'none';
 
 const props = defineProps({
   title: {
@@ -8,19 +18,19 @@ const props = defineProps({
   },
   defaultWrapperClass: {
     type: String,
-    default: 'rounded-md bg-white flex flex-col',
+    default: '',
   },
   defaultHeaderClass: {
     type: String,
-    default: 'font-semibold flex px-4',
+    default: 'card-header',
   },
   defaultFooterClass: {
     type: String,
-    default: 'px-4 flex',
+    default: 'card-footer',
   },
   defaultBodyClass: {
     type: String,
-    default: 'px-4 flex flex-col',
+    default: 'card-body',
   },
   wrapperClass: {
     type: String,
@@ -54,60 +64,57 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  shadow: {
+    type: [Boolean, String] as PropType<CardShadow>,
+    default: false,
+  },
   to: {
     type: String,
     default: '',
+  },
+  color: {
+    type: String,
+    default: 'default',
   },
 });
 
 const {to} = toRefs(props);
 
 const tag = computed(() => (to.value ? 'router-link' : 'div'));
+
+const classes = computed(() => {
+  const shadowClass = props.flat
+    ? 'card--shadow-none'
+    : props.shadow
+    ? `card--shadow-${props.shadow}`
+    : 'card--shadow';
+
+  return [
+    `card card-${props.color}`,
+    props.defaultWrapperClass,
+    props.wrapperClass,
+    shadowClass,
+    {
+      'card--bordered': props.bordered,
+    },
+  ];
+});
 </script>
 
 <template>
-  <component
-    :is="tag"
-    :to="to"
-    :class="[
-      defaultWrapperClass,
-      wrapperClass,
-      {
-        border: bordered,
-        shadow: !flat,
-      },
-    ]"
-  >
+  <component :is="tag" :to="to" :class="classes">
     <slot name="image" />
-    <div
-      v-if="!hideHeader"
-      :class="[
-        defaultHeaderClass,
-        bordered ? 'border-b py-3' : 'pt-3',
-        headerClass,
-      ]"
-    >
+    <div v-if="!hideHeader" :class="[defaultHeaderClass, headerClass]">
+      <slot name="header.prepend" />
       <slot name="header">
-        <div>{{ title }}</div>
+        <div class="card-title">{{ title }}</div>
       </slot>
+      <slot name="header.append" />
     </div>
-    <div
-      :class="[
-        defaultBodyClass,
-        bordered ? 'border-t py-3' : 'py-3',
-        bodyClass,
-      ]"
-    >
+    <div :class="[defaultBodyClass, bodyClass]">
       <slot />
     </div>
-    <div
-      v-if="!hideFooter"
-      :class="[
-        defaultFooterClass,
-        bordered ? 'border-t py-3' : 'pb-3',
-        footerClass,
-      ]"
-    >
+    <div v-if="!hideFooter" :class="[defaultFooterClass, footerClass]">
       <slot name="footer" />
     </div>
   </component>

--- a/packages/card/src/VCard.vue
+++ b/packages/card/src/VCard.vue
@@ -85,7 +85,7 @@ const tag = computed(() => (to.value ? 'router-link' : 'div'));
 const classes = computed(() => {
   const shadowClass = props.flat
     ? 'card--shadow-none'
-    : props.shadow
+    : typeof props.shadow === 'string'
     ? `card--shadow-${props.shadow}`
     : 'card--shadow';
 

--- a/packages/card/src/plugin.js
+++ b/packages/card/src/plugin.js
@@ -1,0 +1,113 @@
+const plugin = require('tailwindcss/plugin');
+
+const card = plugin(function ({addComponents, theme}) {
+  addComponents({
+    ':root': {
+      '--card-bg-color': theme('colors.white'),
+      '--card-color': theme('colors.gray.800'),
+      '--card-border-style': 'solid',
+      '--card-border-width': theme('borderWidth.DEFAULT'),
+      '--card-border-color': theme('borderColor.DEFAULT'),
+      '--card-border-radius': theme('borderRadius.DEFAULT'),
+      '--card-padding-x': theme('padding.4'),
+      '--card-padding-y': theme('padding.3'),
+    },
+    '.card': {
+      display: 'flex',
+      flexDirection: 'column',
+      backgroundColor: 'var(--card-bg-color)',
+      color: 'var(--card-color)',
+      borderRadius: 'var(--card-border-radius)',
+    },
+
+    // elements
+    '.card-header': {
+      fontWeight: theme('fontWeight.semibold'),
+      display: 'flex',
+      padding:
+        'var(--card-padding-y) var(--card-padding-x) 0 var(--card-padding-x)',
+    },
+    '.card-body': {
+      display: 'flex',
+      flexDirection: 'column',
+      padding: 'var(--card-padding-y) var(--card-padding-x)',
+    },
+    '.card-footer': {
+      padding:
+        '0 var(--card-padding-x) var(--card-padding-y) var(--card-padding-x)',
+    },
+
+    // modifiers
+    '.card--bordered': {
+      borderStyle: 'var(--card-border-style)',
+      borderWidth: 'var(--card-border-width)',
+      borderColor: 'var(--card-border-color)',
+    },
+    '.card--bordered .card-header': {
+      borderBottomStyle: 'var(--card-border-style)',
+      borderBottomWidth: 'var(--card-border-width)',
+      borderBottomColor: 'var(--card-border-color)',
+      paddingBottom: 'var(--card-padding-y)',
+    },
+    '.card--bordered .card-footer': {
+      borderTopStyle: 'var(--card-border-style)',
+      borderTopWidth: 'var(--card-border-width)',
+      borderTopColor: 'var(--card-border-color)',
+      paddingTop: 'var(--card-padding-y)',
+    },
+
+    /* Shadows */
+    '.card--shadow': {
+      boxShadow: theme('boxShadow.DEFAULT'),
+    },
+    '.card--shadow-sm': {
+      boxShadow: theme('boxShadow.sm'),
+    },
+    '.card--shadow-md': {
+      boxShadow: theme('boxShadow.md'),
+    },
+    '.card--shadow-lg': {
+      boxShadow: theme('boxShadow.lg'),
+    },
+    '.card--shadow-xl': {
+      boxShadow: theme('boxShadow.xl'),
+    },
+    '.card--shadow-2xl': {
+      boxShadow: theme('boxShadow.2xl'),
+    },
+    '.card--shadow-inner': {
+      boxShadow: theme('boxShadow.inner'),
+    },
+    '.card--shadow-none': {
+      boxShadow: theme('boxShadow.none'),
+    },
+
+    /* Colors */
+    '.card-primary': {
+      '--card-bg-color': theme('colors.primary.500'),
+      '--card-color': theme('colors.white'),
+    },
+    '.card-secondary': {
+      '--card-bg-color': theme('colors.secondary.500'),
+      '--card-color': theme('colors.white'),
+    },
+    '.card-info': {
+      '--card-bg-color': theme('colors.info.500'),
+      '--card-color': theme('colors.white'),
+    },
+    '.card-warning': {
+      '--card-bg-color': theme('colors.warning.500'),
+      '--card-color': theme('colors.white'),
+    },
+    '.card-success': {
+      '--card-bg-color': theme('colors.success.500'),
+      '--card-color': theme('colors.white'),
+    },
+    '.card-error': {
+      '--card-bg-color': theme('colors.error.500'),
+      '--card-color': theme('colors.white'),
+    },
+  });
+});
+
+module.exports = card;

--- a/packages/card/src/plugin.js
+++ b/packages/card/src/plugin.js
@@ -33,6 +33,8 @@ const card = plugin(function ({addComponents, theme}) {
       padding: 'var(--card-padding-y) var(--card-padding-x)',
     },
     '.card-footer': {
+      display: 'flex',
+      gap: theme('spacing.2'),
       padding:
         '0 var(--card-padding-x) var(--card-padding-y) var(--card-padding-x)',
     },

--- a/packages/tailwind-config/package.json
+++ b/packages/tailwind-config/package.json
@@ -14,6 +14,7 @@
     "@gits-id/alert": "^0.11.11-alpha.0",
     "@gits-id/button": "^0.11.10",
     "@gits-id/app-bar": "^0.11.11-alpha.0",
+    "@gits-id/card": "^0.11.10",
     "@gits-id/tailwind-components": "^0.11.10",
     "@gits-id/theme": "^0.11.10",
     "@gits-id/utils": "^0.11.10",

--- a/packages/tailwind-config/preset.js
+++ b/packages/tailwind-config/preset.js
@@ -19,5 +19,6 @@ module.exports = {
     require('@gits-id/alert/plugin'),
     require('@gits-id/app-bar/plugin'),
     require('@gits-id/avatar/plugin'),
+    require('@gits-id/card/plugin'),
   ],
 };


### PR DESCRIPTION
### Description

- New tailwind plugin for card component
- New card docs
- New slots: `header.prepend` and `header.prepend`