### PR TITLE
fix(VDataTable); fix incorrect initial state for header state

### DIFF
--- a/packages/table/src/VDataTable.vue
+++ b/packages/table/src/VDataTable.vue
@@ -258,7 +258,7 @@ const computedHeaders = computed(() =>
       ({
         ...header,
         sortable: header.hasOwnProperty('sortable') ? header.sortable : true,
-        sorting: 'asc',
+        sorting: '',
       } as VDataTableHeader),
   ),
 );


### PR DESCRIPTION
This should fix incorrect initial sort state on datatable component.

Previously, the component assumes that initial sort state is `asc` which is not always the case, causing possible mismatch between actual data being presented and the table state.

This fix set the sort initial to not make assumption of the state of initial data, letting dev to manually set the state through `sortBy` prop of the component if initial sort state is preferred.