### PR TITLE
feat(Forms.VInput): add validationMode feature

### DIFF
--- a/packages/forms/src/checkbox/VCheckbox.stories.ts
+++ b/packages/forms/src/checkbox/VCheckbox.stories.ts
@@ -1,4 +1,5 @@
 import MyCheckbox from './VCheckbox.vue';
+import {ref} from 'vue';
 import {themeColors} from '@gits-id/utils/colors';
 import {sizes} from '@gits-id/utils/sizes';
 import {Meta, Story} from '@storybook/vue3';
@@ -127,9 +128,9 @@ export const Validation: Story<{}> = () => ({
   setup() {
     const schema = object({
       agreement: boolean()
-        .oneOf([true], 'You must agree to terms and condition')
-        .required()
-        .label('Agreement'),
+          .oneOf([true], 'You must agree to terms and condition')
+          .required()
+          .label('Agreement'),
     });
 
     const {handleSubmit, resetForm, values, errors} = useForm({
@@ -161,3 +162,62 @@ export const Validation: Story<{}> = () => ({
     </form>
 `,
 });
+
+export const ValidationMode: Story<{}> = () => ({
+  components: {VCheckbox: MyCheckbox, VBtn},
+  setup() {
+    const schema = object({
+      agreement_eager: boolean()
+          .oneOf([true], 'You must agree to terms and condition')
+          .required()
+          .label('Agreement'),
+      agreement_aggressive: boolean()
+          .oneOf([true], 'You must agree to terms and condition')
+          .required()
+          .label('Agreement'),
+    });
+
+    const modes = ref(['eager', 'aggressive'])
+
+    const {handleSubmit, resetForm, values, errors} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        agreement_eager: false,
+        agreement_aggressive: false,
+      },
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    return {onSubmit, resetForm, values, errors, modes};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <div class="flex flex-wrap gap-4">
+      <fieldset
+          class="border-none flex-1"
+          v-for="mode in modes"
+          :key="mode"
+      >
+        <legend>Mode: {{ mode }}</legend>
+
+        <v-checkbox
+            wrapper-class="mb-4"
+            :name="'agreement_'+mode"
+            label="Agreement"
+            :validation-mode="mode"
+        />
+      </fieldset>
+    </div>
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+    <div class="my-5">Debug:</div>
+    <pre>{{ {errors, values} }}</pre>
+    </form>
+  `,
+});
+

--- a/packages/forms/src/form-select/VFormSelect.stories.ts
+++ b/packages/forms/src/form-select/VFormSelect.stories.ts
@@ -167,6 +167,95 @@ export const Validation: Story<{}> = (args) => ({
 `,
 });
 
+export const ValidationMode: Story<{}> = () => ({
+  components: {VFormSelect, VBtn},
+  setup() {
+    const schema = object({
+      genre_eager: string().required()
+          .test('isCorrect',
+              ({label}) => `${label} is not correct`,
+              (val, ctx) => {
+                return !!(['E', 'A', 'U', 'I', 'O'].find(e => e === val?.charAt(0)?.toUpperCase()))
+              })
+          .label('Genre'),
+      genre_aggressive: string().required()
+          .test('isCorrect',
+              ({label}) => `${label} is not correct`,
+              (val, ctx) => {
+                return !!(['E', 'A', 'U', 'I', 'O'].find(e => e === val?.charAt(0)?.toUpperCase()))
+              })
+          .label('Genre'),
+    });
+
+    const modes = ref(['eager', 'aggressive'])
+    const genres = ref([
+      {
+        text: 'Select Genre that starts with a vowel',
+        value: '',
+        disabled: true,
+      },
+      {
+        text: 'Pop',
+        value: 'pop',
+      },
+      {
+        text: 'Rock',
+        value: 'rock',
+      },
+      {
+        text: 'Hip-Hop',
+        value: 'hiphop',
+      },
+      {
+        text: 'Electronic',
+        value: 'electronic',
+      },
+      {
+        text: 'Opera',
+        value: 'opera',
+      },
+    ]);
+
+    const {handleSubmit, resetForm, values, errors} = useForm({
+      validationSchema: schema,
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    return {onSubmit, resetForm, values, errors, modes, genres};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <div class="flex flex-wrap gap-4">
+      <fieldset
+          class="border-none flex-1"
+          v-for="mode in modes"
+          :key="mode"
+      >
+        <legend>Mode: {{ mode }}</legend>
+
+        <v-form-select
+            wrapper-class="mb-4"
+            :items="genres"
+            :name="'genre_'+mode"
+            label="Genre"
+            placeholder="Select your genre"
+            :validation-mode="mode"
+        />
+      </fieldset>
+    </div>
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+    <div class="my-5">Debug:</div>
+    <pre>{{ {errors, values} }}</pre>
+    </form>
+  `,
+});
+
 export const IntialValues: Story<{}> = (args) => ({
   components: {VBtn, VFormSelect},
   setup() {

--- a/packages/forms/src/form-select/VFormSelect.vue
+++ b/packages/forms/src/form-select/VFormSelect.vue
@@ -65,21 +65,30 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  validationMode: {
+    type: String as PropType<"aggressive"|"eager">,
+    default: 'aggressive',
+  },
 });
 
 const emit = defineEmits(['update:modelValue']);
 
-const {modelValue, value, itemText, itemValue, error, name, disabled, rules} =
+const {modelValue, value, itemText, itemValue, error, name, disabled, rules, validationMode,} =
   toRefs(props);
 
-const {value: inputValue, errorMessage} = useField(name, rules, {
-  initialValue: value.value || modelValue.value,
-});
+const isEagerValidation = computed(() => {
+  return validationMode.value === 'eager';
+})
 
 const message = computed(() => {
   return errorMessage.value || props.errorMessages[0];
 });
 
+
+const {value: inputValue, errorMessage, validate} = useField(name, rules, {
+  initialValue: value.value || modelValue.value,
+  validateOnValueUpdate: !isEagerValidation.value
+});
 const {class: sizeClass} = useTextSize(props.size);
 const inputClass = computed(() => useInputClasses(error.value));
 
@@ -89,6 +98,10 @@ const classes = computed(() => {
 
 watch(inputValue, (val) => {
   emit('update:modelValue', val);
+
+  if(errorMessage.value && isEagerValidation.value){
+    validate();
+  }
 });
 
 watch(modelValue, (val) => {
@@ -102,6 +115,12 @@ const getValue = (option: string | Record<string, any>) => {
 const getText = (option: string | Record<string, any>) => {
   return typeof option === 'string' ? option : option[itemText.value];
 };
+
+const handleBlur = () => {
+  if(isEagerValidation.value){
+    validate();
+  }
+}
 </script>
 
 <template>
@@ -111,6 +130,7 @@ const getText = (option: string | Record<string, any>) => {
     </label>
     <select
       v-model="inputValue"
+      @blur="handleBlur"
       class="w-full block transition duration-300"
       :class="classes"
       :disabled="disabled"

--- a/packages/forms/src/input/VInput.stories.ts
+++ b/packages/forms/src/input/VInput.stories.ts
@@ -10,6 +10,7 @@ import {object, string} from 'yup';
 import FieldArrayStory from './stories/FieldArray.story.vue';
 import FieldArrayOfObject from './stories/FieldArrayOfObject.story.vue';
 import FieldArrayNestedComponent from './stories/FieldArrayNested.story.vue';
+import {ref} from "vue";
 
 export default {
   title: 'Forms/Input',
@@ -22,6 +23,10 @@ export default {
     color: {
       control: 'select',
       options: themeColors,
+    },
+    validationMode: {
+      control: 'select',
+      options: ['aggressive', 'eager'],
     },
   },
   args: {
@@ -39,6 +44,7 @@ export default {
     shadow: false,
     text: false,
     label: '',
+    validationMode: 'aggressive'
   },
 } as Meta;
 
@@ -488,6 +494,50 @@ export const Validation: Story<VInputProps> = (args) => ({
       </div>
     </form>
 `,
+});
+
+export const ValidationMode: Story<VInputProps> = (args) => ({
+  components: {VInput, VBtn},
+  setup() {
+    const schema = object({
+      name_eager: string().required().label('Name'),
+      email_eager: string().required().email().label('Email'),
+      name_aggressive: string().required().label('Name'),
+      email_aggressive: string().required().email().label('Email'),
+    });
+
+    const {handleSubmit, resetForm} = useForm({
+      validationSchema: schema,
+    });
+
+    const modes = ref(['eager', 'aggressive'])
+
+    const onSubmit =
+            handleSubmit((values) => {
+              alert(JSON.stringify(values));
+            });
+
+    return {modes, onSubmit, resetForm};
+  },
+  template: `
+    <form @submit="onSubmit">
+      <div class="flex flex-wrap gap-4">
+        <fieldset
+            class="border-none flex-1"
+            v-for="mode in modes"
+            :key="mode"
+        >
+          <legend>Mode: {{ mode }}</legend>
+          <v-input wrapper-class="mb-2" :name="'name_'+mode" label="Name" placeholder="Your Name" :validation-mode="mode"/>
+          <v-input wrapper-class="mb-2" :name="'email_'+mode" label="Email" placeholder="Your Email" :validation-mode="mode"/>
+        </fieldset>
+      </div>
+      <div class="mt-4">
+        <v-btn type="submit">Submit</v-btn>
+        <v-btn type="button" text @click="resetForm">Reset</v-btn>
+      </div>
+    </form>
+  `,
 });
 
 export const FieldArrays: Story<VInputProps> = () => ({

--- a/packages/forms/src/input/VInputRange.stories.ts
+++ b/packages/forms/src/input/VInputRange.stories.ts
@@ -1,9 +1,10 @@
 import {Meta, Story} from '@storybook/vue3';
 import { useForm } from 'vee-validate';
 import {ref} from 'vue';
-import { object, string } from 'yup';
+import {object} from 'yup';
 import VInputRange from './VInputRange.vue';
 import VBtn from '@gits-id/button';
+import MyCheckbox from "../checkbox/VCheckbox.vue";
 
 export default {
   title: 'Forms/InputRange',
@@ -97,3 +98,79 @@ export const Validation: Story<{}> = () => ({
     </form>
 `,
 });
+
+export const ValidationMode: Story<{}> = () => ({
+  components: {VInputRange, VBtn},
+  setup() {
+    const schema = object({
+      score_eager: object()
+          .required()
+          .test(
+              'isBetween',
+              ({ label }) => `${label} must be between 25-75`, // a message can also be a function
+              (value, testContext) => {
+                return (value.min >= 25 && value.max <= 75);
+              })
+          .label('Range'),
+      score_aggressive: object()
+          .required()
+          .test(
+              'isBetween',
+              ({ label }) => `${label} must be between 25-75`, // a message can also be a function
+              (value, testContext) => {
+                return (value.min >= 25 && value.max <= 75);
+              })
+          .label('Range'),
+    });
+
+    const modes = ref(['eager', 'aggressive'])
+
+    const {handleSubmit, resetForm, values, errors} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        score_eager: {
+          min: 0,
+          max: 0
+        },
+        score_aggressive: {
+          min: 0,
+          max: 0
+        },
+      },
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    return {onSubmit, resetForm, values, errors, modes};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <div class="flex flex-wrap gap-4">
+      <fieldset
+          class="border-none flex-1"
+          v-for="mode in modes"
+          :key="mode"
+      >
+        <legend>Mode: {{ mode }}</legend>
+
+        <v-input-range
+            wrapper-class="mb-4"
+            :name="'score_'+mode"
+            label="Select Your Score"
+            :validation-mode="mode"
+            :show-input="true"
+        />
+      </fieldset>
+    </div>
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+    <div class="my-5">Debug:</div>
+    <pre>{{ {errors, values} }}</pre>
+    </form>
+  `,
+});
+

--- a/packages/forms/src/radio/VRadioGroup.stories.ts
+++ b/packages/forms/src/radio/VRadioGroup.stories.ts
@@ -1,8 +1,9 @@
 import {Meta, Story} from '@storybook/vue3';
 import {useForm} from 'vee-validate';
-import {object, number} from 'yup';
+import {object, number, string} from 'yup';
 import VRadioGroup from './VRadioGroup.vue';
 import VBtn from '@gits-id/button';
+import {ref} from "vue";
 
 const items = [...Array(5)].map((v, k) => ({
   text: `Item ${k + 1}`,
@@ -133,3 +134,79 @@ export const Validation: Story<{}> = () => ({
     </form>
 `,
 });
+
+export const ValidationMode: Story<{}> = () => ({
+  components: {VRadioGroup, VBtn},
+  setup() {
+    const items = ['liquid', 'gas', 'solid'];
+
+    const schema = object({
+      choose_eager: string()
+          .oneOf(items)
+          .test(
+              'is_correct',
+              ({ label }) => `${label} is incorrect.`, // a message can also be a function
+              (value) => {
+                return value === 'liquid';
+              })
+          .required()
+          .label('Answer'),
+      choose_aggressive: string()
+          .oneOf(items)
+          .test(
+              'is_correct',
+              ({ label }) => `${label} is incorrect.`, // a message can also be a function
+              (value) => {
+                return value === 'liquid';
+              })
+          .required()
+          .label('Answer'),
+    });
+
+    const modes = ref(['eager', 'aggressive'])
+
+    const {handleSubmit, resetForm, values, errors} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        choose_eager: '',
+        choose_aggressive: '',
+      },
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    return {onSubmit, resetForm, values, errors, modes, items};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <div class="flex flex-wrap gap-4">
+      <fieldset
+          class="border-none flex-1"
+          v-for="mode in modes"
+          :key="mode"
+      >
+        <legend>Mode: {{ mode }}</legend>
+        
+        <p>
+          Question: Rain is water in ... form
+        </p>
+        <v-radio-group
+            :name="'choose_'+mode"
+            label="Choose"
+            :items="items"
+            :validation-mode="mode"
+        />
+      </fieldset>
+    </div>
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+    <div class="my-5">Debug:</div>
+    <pre>{{ {errors, values} }}</pre>
+    </form>
+  `,
+});
+

--- a/packages/forms/src/textarea/Textarea.stories.ts
+++ b/packages/forms/src/textarea/Textarea.stories.ts
@@ -4,6 +4,7 @@ import VTextarea from './Textarea.vue';
 import VBtn from '@gits-id/button';
 import {object, string} from 'yup';
 import {useForm} from 'vee-validate';
+import {ref} from "vue";
 
 export default {
   title: 'Forms/Textarea',
@@ -123,3 +124,54 @@ export const Validation: Story<{}> = () => ({
     </form>
 `,
 });
+
+export const ValidationMode: Story<{}> = () => ({
+  components: {VTextarea, VBtn},
+  setup() {
+    const schema = object({
+      bio_eager: string().required().min(5).max(150).label('Bio'),
+      bio_aggressive: string().required().min(5).max(150).label('Bio'),
+    });
+
+    const modes = ref(['eager', 'aggressive'])
+
+    const {handleSubmit, resetForm, values, errors} = useForm({
+      validationSchema: schema,
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    return {onSubmit, resetForm, values, errors, modes};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <div class="flex flex-wrap gap-4">
+      <fieldset
+          class="border-none flex-1"
+          v-for="mode in modes"
+          :key="mode"
+      >
+        <legend>Mode: {{ mode }}</legend>
+
+        <v-textarea
+            wrapper-class="mb-4"
+            :name="'bio_'+mode"
+            label="Bio"
+            placeholder="Enter your bio"
+            input-class="italic"
+            :validation-mode="mode"
+        />
+      </fieldset>
+    </div>
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+    <div class="my-5">Debug:</div>
+    <pre>{{ {errors, values} }}</pre>
+    </form>
+  `,
+});
+


### PR DESCRIPTION
This changes would allow toggling between `eager` and `aggressive` mode of validation.

In `eager` mode, validation will only run on `submit`, `blur`. However when input state is invalid, it will run validation on `change` (`aggressive` mode), only reverting back if input is valid.

In `aggressive` mode, validation will run on `submit`, `blur`, and every `change`.

Implementation is taken from official docs [here](https://vee-validate.logaretm.com/v4/guide/composition-api/validation)