### PR TITLE
chore: define missing dependencies

### DIFF
--- a/packages/app-bar/package.json
+++ b/packages/app-bar/package.json
@@ -28,6 +28,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/app-bar.umd.js",
   "unpkg": "dist/app-bar.iife.js",
   "jsdelivr": "dist/app-bar.iife.js",

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -22,6 +22,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/collapsible.umd.js",
   "unpkg": "dist/collapsible.iife.js",
   "jsdelivr": "dist/collapsible.iife.js",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -31,6 +31,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/forms.umd.js",
   "unpkg": "dist/forms.iife.js",
   "jsdelivr": "dist/forms.iife.js",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -24,6 +24,10 @@
     "vitest": "^0.12.4",
     "vue-tsc": "^0.40.1"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/icon.js",
   "unpkg": "dist/icon.iife.js",
   "jsdelivr": "dist/icon.iife.js",

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -28,6 +28,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/layouts.umd.js",
   "unpkg": "dist/layouts.iife.js",
   "jsdelivr": "dist/layouts.iife.js",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -19,7 +19,6 @@
   "license": "ISC",
   "dependencies": {
     "@gits-id/collapsible": "^0.7.3",
-    "@iconify/vue": "^3.2.1",
     "vue": "^3.2.33",
     "vue-router": "^4.0.16"
   },
@@ -36,6 +35,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4",
     "vue-tsc": "^0.38.2"
+  },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
   },
   "main": "dist/list.js",
   "unpkg": "dist/list.iife.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -15,12 +15,11 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@iconify/vue": "^3.2.1",
+    "@gits-id/collapsible": "^0.12.0-alpha.1",
     "vue": "^3.2.31",
     "vue-router": "^4.0.13"
   },
   "devDependencies": {
-    "@gits-id/collapsible": "^0.12.0-alpha.1",
     "@gits-id/tailwind-config": "^0.12.0-alpha.1",
     "@gits-id/utils": "^0.12.0-alpha.1",
     "@headlessui/vue": "^1.6.0",
@@ -30,6 +29,10 @@
     "vee-validate": "^4.5.9",
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
+  },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
   },
   "main": "dist/menu.umd.js",
   "unpkg": "dist/menu.iife.js",

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -29,6 +29,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/menus.umd.js",
   "unpkg": "dist/menus.iife.js",
   "jsdelivr": "dist/menus.iife.js",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -29,6 +29,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/modal.umd.js",
   "unpkg": "dist/modal.iife.js",
   "jsdelivr": "dist/modal.iife.js",

--- a/packages/multi-select/package.json
+++ b/packages/multi-select/package.json
@@ -33,6 +33,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/multi-select.umd.js",
   "unpkg": "dist/multi-select.iife.js",
   "jsdelivr": "dist/multi-select.iife.js",

--- a/packages/nav-drawer/package.json
+++ b/packages/nav-drawer/package.json
@@ -32,6 +32,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/nav-drawer.umd.js",
   "unpkg": "dist/nav-drawer.iife.js",
   "jsdelivr": "dist/nav-drawer.iife.js",

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -31,6 +31,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/navbar.umd.js",
   "unpkg": "dist/navbar.iife.js",
   "jsdelivr": "dist/navbar.iife.js",

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -33,6 +33,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/pages.js",
   "unpkg": "dist/pages.iife.js",
   "jsdelivr": "dist/pages.iife.js",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -18,8 +18,6 @@
   "dependencies": {
     "@gits-id/badge": "^0.12.0-alpha.1",
     "@gits-id/card": "^0.12.0-alpha.1",
-    "@iconify/vue": "^3.2.1",
-    "feather-icons": "^4.28.0",
     "vue": "^3.2.31"
   },
   "devDependencies": {
@@ -32,6 +30,11 @@
     "vee-validate": "^4.5.9",
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
+  },
+  "peerDependencies": {
+    "feather-icons": "^4.28.0",
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
   },
   "main": "dist/stats.umd.js",
   "unpkg": "dist/stats.iife.js",

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -30,6 +30,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/switch.umd.js",
   "unpkg": "dist/switch.iife.js",
   "jsdelivr": "dist/switch.iife.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -31,6 +31,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/tabs.umd.js",
   "unpkg": "dist/tabs.iife.js",
   "jsdelivr": "dist/tabs.iife.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -32,6 +32,9 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6"
+  },
   "main": "dist/toast.umd.js",
   "unpkg": "dist/toast.iife.js",
   "jsdelivr": "dist/toast.iife.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -47,8 +47,13 @@
     "@gits-id/toast": "^0.12.0-alpha.1",
     "@gits-id/tooltip": "^0.12.0-alpha.1",
     "@gits-id/utils": "^0.12.0-alpha.1",
+    "@headlessui/vue": "^1.6.0",
     "@vue/test-utils": "^2.0.0-rc.17",
     "vue": "^3.2.33"
+  },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
   },
   "main": "./dist/ui.umd.js",
   "unpkg": "./dist/ui.iife.js",


### PR DESCRIPTION
This merge fix issues with yarn in strict mode complaining about dependencies not being explicitly defined in packages.

this PR set :
- `@heroicons` and `@iconify` package as `peerDependencies`, requiring projects using `gits-ui` package to separately install these two libs along with `gits-ui` package.
- `@headlessui/vue` as `devDependencies` 