### PR TITLE
Pass change event to vee validate and v model

### DIFF
--- a/packages/forms/src/input/VInputRange.stories.ts
+++ b/packages/forms/src/input/VInputRange.stories.ts
@@ -54,15 +54,24 @@ export const Validation: Story<{}> = () => ({
   components: {VInputRange, VBtn},
   setup() {
     const schema = object({
-      score: string()
+      score: object()
         .required()
+          .test(
+              'isBetween',
+              ({ label }) => `${label} must be between 25-75`, // a message can also be a function
+              (value, testContext) => {
+                return (value.min >= 25 && value.max <= 75);
+              })
         .label('Range'),
     });
 
     const {handleSubmit, resetForm, values, errors} = useForm({
       validationSchema: schema,
       initialValues: {
-        score: 0,
+        score: {
+          min: 0,
+          max: 0
+        },
       },
     });
 

--- a/packages/forms/src/input/VInputRange.vue
+++ b/packages/forms/src/input/VInputRange.vue
@@ -1,13 +1,13 @@
 <script setup>
-import {ref, toRefs, onMounted} from 'vue';
+import {ref, watch, toRefs, onMounted} from 'vue';
 import {useRange} from './useRange';
 import {useInputClasses} from '@gits-id/utils';
 import {useField} from 'vee-validate';
 
 const props = defineProps({
   modelValue: {
-    type: String,
-    default: '',
+    type: Object,
+    default: () => ({min: 0, max:0}),
   },
   min: {
     type: Number,
@@ -51,7 +51,7 @@ const {modelValue, showInput, name, rules} = toRefs(props);
 
 const emit = defineEmits(['update:modelValue']);
 
-const {value, errorMessage} = useField(name, rules, {
+const {value, errorMessage, handleChange} = useField(name, rules, {
   initialValue: modelValue,
 });
 
@@ -69,6 +69,16 @@ const {
   maxTrigger,
   validation,
 } = useRange(props.min, props.max, props.step);
+
+watch([minValue, maxValue], (val) => {
+  const nuValue = {
+    min: val[0],
+    max: val[1],
+  };
+
+  handleChange(nuValue);
+  emit('update:modelValue', nuValue)
+})
 
 onMounted(() => {
   minTrigger();


### PR DESCRIPTION
This PR fix issue in VInputRange where value changes are not being reflected by vee validate form values nor notified to parent outside component.

Now, to listen to value changes (outside vee-validate), people can use `input:modelValue` with value is an object formatted like this : `{min: 0, max:0}`.

The `Validation` story for this component has also been updated to properly show validation usage.

Note: This may introduce BREAKING CHANGES. As the `modelValue` is changed from `string` to `object` to make validating the values easier.