### PR TITLE
docs(Spinner): add vuepress entry for spinner component

### DIFF
--- a/docs/.vitepress/config.js
+++ b/docs/.vitepress/config.js
@@ -102,6 +102,10 @@ export default defineConfig({
             link: '/components/select',
           },
           {
+            text: 'Spinner',
+            link: '/components/spinner',
+          },
+          {
             text: 'Tabs',
             link: '/components/tabs',
           },

--- a/docs/components/spinner.md
+++ b/docs/components/spinner.md
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+import {VSpinner} from '@gits-id/ui';
+</script>
+
+# Spinner
+
+## Usage
+
+### Basic Usage
+
+```vue
+<template>
+  <!-- VSpinner is registered globally -->
+  <VSpinner />
+</template>
+```
+
+<LivePreview src="components-spinner--default" height="auto" />
+
+::: info
+The `VSpinner` component is registered globally when you install with `@gits-id/ui`. So you don't need to import it manually.
+:::
+
+### Color
+
+- **prop**: `color`
+- **type**: `string`
+- **default**: ``
+- **required**: `false`
+
+Use `color` to different color style to the spinner.
+
+```vue
+<template>
+  <VSpinner />
+  <VSpinner color="primary" />
+  <VSpinner color="secondary" />
+  <VSpinner color="info" />
+  <VSpinner color="warning" />
+  <VSpinner color="success" />
+  <VSpinner color="error" />
+  <VSpinner color="dark" />
+</template>
+```
+
+<LivePreview src="components-spinner--colors" height="auto"/>
+
+### Size
+
+Use `xSmall`, `small`, `large` or `xLager` prop to easily switch the size of the spinner.
+
+```vue
+<template>
+  <v-spinner />
+  <v-spinner xSmall />
+  <v-spinner small />
+  <v-spinner large />
+  <v-spinner xLarge />
+</template>
+```
+
+<LivePreview src="components-spinner--sizes" height="auto" />
+
+## Props
+
+| Name            | Type                                               | Default   |
+|-----------------|----------------------------------------------------|-----------|
+| [color](#color) | `string` , [available colors](/guide/theme#colors) | `default` |
+| [xSmall](#size) | `boolean`                                          | `false`   |
+| [small](#size)  | `boolean`                                          | `false`   |
+| [large](#size)  | `boolean`                                          | `false`   |
+| [xLarge](#size) | `boolean`                                          | `false`   |
+
+## Manual Installation
+
+You can also install the `Spinner` component individually via `@gits-id/spnner` package:
+
+```bash
+yarn install @gits-id/spinner
+```
+
+```vue
+<script setup lang="ts">
+import VSpinner from '@gits-id/spinner';
+</script>
+
+<template>
+  <VSpinner />
+</template>
+```
+
+## Storybook
+
+View Storybook documentation [here](https://gits-ui.web.app/?path=/story/components-spinner--default).

--- a/packages/spinner/README.md
+++ b/packages/spinner/README.md
@@ -36,7 +36,7 @@ import Spinner from '@gits-id/spinner';
 
 ## Documentation
 
-View `Spinner` documentation [here](https://gits-ui.web.app/?path=/story/components-spinner--default).
+View `Spinner` documentation [here](https://gitsindonesia.github.io/ui-component/components/spinner.html).
 
 ## License
 

--- a/packages/spinner/src/VSpinner.stories.js
+++ b/packages/spinner/src/VSpinner.stories.js
@@ -37,52 +37,89 @@ Default.parameters = {
   },
 };
 
-export const XSmall = Template.bind({});
-XSmall.args = {
-  xSmall: true,
-};
-XSmall.storyName = 'Extra Small';
-XSmall.parameters = {
-  docs: {
-    source: {
-      code: '<v-spinner color="primary" x-small />',
-    },
+export const Sizes = (args) => ({
+  components: {
+    VSpinner,
   },
-};
+  setup() {
+    const sizes = ['default', 'xSmall', 'small', 'large', 'xLarge']
 
-export const Small = Template.bind({});
-Small.args = {
-  small: true,
-};
-Small.parameters = {
-  docs: {
-    source: {
-      code: '<v-spinner color="primary" small />',
-    },
-  },
-};
+    const nuArgs = {
+      args: sizes.map((e) => {
+        if(e === 'default'){
+          return args;
+        }
 
-export const Large = Template.bind({});
-Large.args = {
-  large: true,
-};
-Large.parameters = {
-  docs: {
-    source: {
-      code: '<v-spinner color="primary" large />',
-    },
-  },
-};
+        return {
+          ...args,
+          [`${e}`]: true,
+        }
+      }),
+      availableSizes : sizes
+    }
 
-export const XLarge = Template.bind({});
-XLarge.args = {
-  xLarge: true,
-};
-XLarge.storyName = 'Extra Large';
-XLarge.parameters = {
+    return {args:nuArgs};
+  },
+  template: `
+    <div class="flex gap-4">
+      <div v-for="(size, idx) in args.availableSizes">
+        <p class="mb-2">{{size}}</p>
+        <v-spinner v-bind="args.args[idx]"/>
+      </div>
+    </div>
+  `,
+});
+Sizes.parameters = {
   docs: {
     source: {
-      code: '<v-spinner color="primary" x-large />',
+      code: `
+<v-spinner />
+<v-spinner xSmall />
+<v-spinner small />
+<v-spinner large />
+<v-spinner xLarge />
+      `,
     },
   },
-};
+}
+
+
+export const Colors = (args) => ({
+  components: {
+    VSpinner,
+  },
+  setup() {
+    const colors = ['default', 'primary', 'secondary', 'info', 'success', 'warning', 'error', 'dark']
+
+    const nuArgs = {
+      args,
+      availableColors : colors
+    }
+
+    return {args:nuArgs};
+  },
+  template: `
+    <div class="flex gap-4">
+      <div v-for="color in args.availableColors">
+        <p class="mb-2">{{color}}</p>
+        <v-spinner v-bind="args.args" :color="color" :key="color"/>
+      </div>
+    </div>
+  `,
+});
+Colors.parameters = {
+  docs: {
+    source: {
+      code: `
+<v-spinner />
+<v-spinner color="primary" />
+<v-spinner color="secondary" />
+<v-spinner color="info" />
+<v-spinner color="success" />
+<v-spinner color="warning" />
+<v-spinner color="error" />
+<v-spinner color="dark" />
+      `,
+    },
+  },
+}


### PR DESCRIPTION
Added new entry in vuepress docs: `Spinner.`

I also updated storybook stories for `Spinner` component to be more concise by making size stories into one single story.