### PR TITLE
Fix issue stepper divider

### DIFF
--- a/packages/steppers/src/Stepper.vue
+++ b/packages/steppers/src/Stepper.vue
@@ -69,9 +69,12 @@ if (!disableRouteActive.value) {
       <StepperItem
         :item="item"
         :index="idx"
+        :active-index="activeIndex"
         :active="linear ? activeIndex >= idx : activeIndex === idx"
         :as="tag"
         :vertical="vertical"
+        :linear="linear"
+        :last="idx === (items.length -1)"
       />
     </template>
   </div>

--- a/packages/steppers/src/StepperDivider.vue
+++ b/packages/steppers/src/StepperDivider.vue
@@ -1,17 +1,20 @@
 <script setup lang="ts">
 defineProps<{
   vertical?: boolean;
+  isActive?: boolean;
 }>();
 </script>
 
 <template>
   <div
     v-if="vertical"
-    class="absolute z-1 border-b border-gray-300 left-1/2 transform -translate-y-1/2 flex align-center items-center align-middle content-center stepper-divider-vertical"
+    class="absolute z-1  top-8 left-4 transform translate-y-[1px] stepper-divider-vertical w-[1px] h-full"
+    :class="isActive ? 'border-l-4 border-blue-300 -translate-x-[2px]' : 'border-l-2 border-gray-300 -translate-x-[1px]'"
   />
   <div
     v-else
-    class="absolute z-1 border-b border-gray-300 top-1/2 transform -translate-x-1/2 flex align-center items-center align-middle content-center stepper-divider h-2"
+    class="absolute z-1  top-4 left-0 transform -translate-x-1/2 flex align-center items-center align-middle content-center stepper-divider h-[1px]"
+    :class="isActive ? 'border-b-4 border-blue-300' : 'border-b-2 border-gray-300'"
   />
 </template>
 

--- a/packages/steppers/src/StepperItem.vue
+++ b/packages/steppers/src/StepperItem.vue
@@ -6,23 +6,28 @@ import {toRefs, computed} from 'vue';
 
 type Props = {
   index: number;
+  activeIndex: number;
   item: StepItem;
   startFrom?: number;
   first?: boolean;
+  last?: boolean;
   active?: boolean;
   as?: string;
   vertical?: boolean;
+  linear?: boolean,
 };
 
 const props = withDefaults(defineProps<Props>(), {
   startFrom: 1,
   first: false,
+  last: false,
   active: false,
   as: 'div',
   vertical: false,
+  linear: false,
 });
 
-const {active, startFrom, first, as, item, index} = toRefs(props);
+const {active, startFrom, first, last, as, item, index} = toRefs(props);
 
 const displayIndex = computed(() => startFrom.value + index.value);
 const isFirst = computed(() => first.value || index.value === 0);
@@ -36,11 +41,16 @@ const to = computed(() => (isRouterLink.value ? item.value.path : ''));
   <component
     :is="as"
     :to="to"
-    class="w-full flex gap-x-2 items-center"
+    class="w-full flex gap-x-2 items-center relative"
     :class="[vertical ? 'flex-row' : 'flex-col']"
   >
-    <div class="relative">
-      <StepperDivider v-if="!isFirst" :vertical="vertical" />
+    <StepperDivider
+        v-if="(vertical && !last) || (!vertical && !isFirst)"
+        :vertical="vertical"
+        :is-active="linear ? (vertical ? activeIndex !== index && active : active) : false"
+        :linear="linear"
+    />
+    <div class="">
       <StepperNumber
         :index="displayIndex"
         :is-active="active"


### PR DESCRIPTION
Fix issue with stepper divider not appearing, or appearing with unexpected styling (incorrect location, incorrect width/height, etc).

This also added handling for `linear` state and improve style to reflect `active` state properly.