### PR TITLE
chore(deps): add heroicons and iconify to dependencies

### DIFF
--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -30,6 +30,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "gitHead": "a66f8d89ce157b912642d9b1f1e2a80991e12ce3",
   "main": "dist/alert.umd.js",
   "unpkg": "dist/alert.iife.js",

--- a/packages/app-bar/package.json
+++ b/packages/app-bar/package.json
@@ -28,10 +28,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/app-bar.umd.js",
   "unpkg": "dist/app-bar.iife.js",
   "jsdelivr": "dist/app-bar.iife.js",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -29,6 +29,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/autocomplete.umd.js",
   "unpkg": "dist/autocomplete.iife.js",
   "jsdelivr": "dist/autocomplete.iife.js",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -28,6 +28,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/badge.umd.js",
   "unpkg": "dist/badge.iife.js",
   "jsdelivr": "dist/badge.iife.js",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -28,6 +28,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/breadcrumbs.umd.js",
   "unpkg": "dist/breadcrumbs.iife.js",
   "jsdelivr": "dist/breadcrumbs.iife.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,6 +23,10 @@
     "vue": "^3.2.33",
     "vue-router": "^4.1.5"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "devDependencies": {
     "@gits-id/tailwind-config": "^0.13.6",
     "@vitejs/plugin-vue": "^2.2.4",

--- a/packages/collapsible/package.json
+++ b/packages/collapsible/package.json
@@ -22,10 +22,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/collapsible.umd.js",
   "unpkg": "dist/collapsible.iife.js",
   "jsdelivr": "dist/collapsible.iife.js",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -29,6 +29,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/dropdown.js",
   "unpkg": "dist/dropdown.iife.js",
   "jsdelivr": "dist/dropdown.iife.js",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -31,10 +31,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/forms.umd.js",
   "unpkg": "dist/forms.iife.js",
   "jsdelivr": "dist/forms.iife.js",

--- a/packages/icon/package.json
+++ b/packages/icon/package.json
@@ -16,17 +16,15 @@
   "license": "MIT",
   "dependencies": {
     "@gits-id/theme": "^0.13.0",
-    "vue": "^3.2.31"
+    "vue": "^3.2.31",
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
   },
   "devDependencies": {
     "@gits-id/tailwind-config": "^0.13.6",
     "vite": "^3.0.0",
     "vitest": "^0.12.4",
     "vue-tsc": "^0.40.1"
-  },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
   },
   "main": "dist/icon.js",
   "unpkg": "dist/icon.iife.js",

--- a/packages/layouts/package.json
+++ b/packages/layouts/package.json
@@ -28,10 +28,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/layouts.umd.js",
   "unpkg": "dist/layouts.iife.js",
   "jsdelivr": "dist/layouts.iife.js",

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -36,10 +36,7 @@
     "typescript": "^4.6.2",
     "vite": "^3.0.0",
     "vitest": "^0.12.4",
-    "vue-tsc": "^0.38.2"
-  },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
+    "vue-tsc": "^0.38.2",
     "@iconify/vue": "^3.2.1"
   },
   "main": "dist/list.js",

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "@gits-id/collapsible": "^0.13.0",
     "vue": "^3.2.31",
-    "vue-router": "^4.0.13"
+    "vue-router": "^4.0.13",
+    "@iconify/vue": "^3.2.1"
   },
   "devDependencies": {
     "@gits-id/tailwind-config": "^0.13.6",
@@ -29,10 +30,6 @@
     "vee-validate": "^4.5.9",
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
-  },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
   },
   "main": "dist/menu.umd.js",
   "unpkg": "dist/menu.iife.js",

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -33,6 +33,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/menus.umd.js",
   "unpkg": "dist/menus.iife.js",
   "jsdelivr": "dist/menus.iife.js",

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -29,10 +29,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/modal.umd.js",
   "unpkg": "dist/modal.iife.js",
   "jsdelivr": "dist/modal.iife.js",

--- a/packages/multi-select/package.json
+++ b/packages/multi-select/package.json
@@ -35,10 +35,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/multi-select.umd.js",
   "unpkg": "dist/multi-select.iife.js",
   "jsdelivr": "dist/multi-select.iife.js",

--- a/packages/nav-drawer/package.json
+++ b/packages/nav-drawer/package.json
@@ -31,10 +31,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/nav-drawer.umd.js",
   "unpkg": "dist/nav-drawer.iife.js",
   "jsdelivr": "dist/nav-drawer.iife.js",

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -31,10 +31,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/navbar.umd.js",
   "unpkg": "dist/navbar.iife.js",
   "jsdelivr": "dist/navbar.iife.js",

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -34,9 +34,5 @@
     "nuxt": "^3.0.0",
     "postcss-custom-properties": "^10.0.0"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "gitHead": "a66f8d89ce157b912642d9b1f1e2a80991e12ce3"
 }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -34,5 +34,9 @@
     "nuxt": "^3.0.0",
     "postcss-custom-properties": "^10.0.0"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "gitHead": "a66f8d89ce157b912642d9b1f1e2a80991e12ce3"
 }

--- a/packages/pages/package.json
+++ b/packages/pages/package.json
@@ -33,10 +33,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/pages.js",
   "unpkg": "dist/pages.iife.js",
   "jsdelivr": "dist/pages.iife.js",

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -33,6 +33,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/select.umd.js",
   "unpkg": "dist/select.iife.js",
   "jsdelivr": "dist/select.iife.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -27,6 +27,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/services.umd.js",
   "unpkg": "dist/services.iife.js",
   "jsdelivr": "dist/services.iife.js",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -19,6 +19,7 @@
     "@gits-id/badge": "^0.13.6",
     "@gits-id/card": "^0.13.6",
     "@gits-id/icon": "^0.13.6",
+    "@iconify/vue": "^3.2.1",
     "vue": "^3.2.31"
   },
   "devDependencies": {

--- a/packages/switch/package.json
+++ b/packages/switch/package.json
@@ -30,10 +30,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/switch.umd.js",
   "unpkg": "dist/switch.iife.js",
   "jsdelivr": "dist/switch.iife.js",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -31,6 +31,10 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
+  "peerDependencies": {
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
+  },
   "main": "dist/table.umd.js",
   "unpkg": "dist/table.iife.js",
   "jsdelivr": "dist/table.iife.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -31,10 +31,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/tabs.umd.js",
   "unpkg": "dist/tabs.iife.js",
   "jsdelivr": "dist/tabs.iife.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -33,7 +33,8 @@
     "vitest": "^0.12.4"
   },
   "peerDependencies": {
-    "@heroicons/vue": "^1.0.6"
+    "@heroicons/vue": "^1.0.6",
+    "@iconify/vue": "^3.2.1"
   },
   "main": "dist/toast.umd.js",
   "unpkg": "dist/toast.iife.js",

--- a/packages/toast/package.json
+++ b/packages/toast/package.json
@@ -32,10 +32,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/toast.umd.js",
   "unpkg": "dist/toast.iife.js",
   "jsdelivr": "dist/toast.iife.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,10 +52,6 @@
     "@vue/test-utils": "^2.0.0-rc.17",
     "vue": "^3.2.33"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "./dist/ui.umd.js",
   "unpkg": "./dist/ui.iife.js",
   "jsdelivr": "./dist/ui.iife.js",


### PR DESCRIPTION
Add missing peer deps declaration for `heroicons` and `iconify` in package that requires `icon` package.

These packages will require the two package above to be installed separately outside `@gits-id/ui` or `@gits-id/ui-nuxt`.