### PR TITLE
Chore/missing dep

### DIFF
--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -30,10 +30,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "gitHead": "8104720a06b60ca92b79f9b6ce89108faa68bba5",
   "main": "dist/alert.umd.js",
   "unpkg": "dist/alert.iife.js",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -29,10 +29,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/autocomplete.umd.js",
   "unpkg": "dist/autocomplete.iife.js",
   "jsdelivr": "dist/autocomplete.iife.js",

--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -28,10 +28,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/badge.umd.js",
   "unpkg": "dist/badge.iife.js",
   "jsdelivr": "dist/badge.iife.js",

--- a/packages/breadcrumbs/package.json
+++ b/packages/breadcrumbs/package.json
@@ -28,10 +28,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/breadcrumbs.umd.js",
   "unpkg": "dist/breadcrumbs.iife.js",
   "jsdelivr": "dist/breadcrumbs.iife.js",

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -23,10 +23,6 @@
     "vue": "^3.2.33",
     "vue-router": "^4.1.5"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "devDependencies": {
     "@gits-id/tailwind-config": "^0.13.16",
     "@vitejs/plugin-vue": "^2.2.4",

--- a/packages/dropdown/package.json
+++ b/packages/dropdown/package.json
@@ -29,10 +29,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/dropdown.js",
   "unpkg": "dist/dropdown.iife.js",
   "jsdelivr": "dist/dropdown.iife.js",

--- a/packages/menus/package.json
+++ b/packages/menus/package.json
@@ -33,10 +33,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/menus.umd.js",
   "unpkg": "dist/menus.iife.js",
   "jsdelivr": "dist/menus.iife.js",

--- a/packages/multi-select/package.json
+++ b/packages/multi-select/package.json
@@ -19,6 +19,7 @@
     "@gits-id/badge": "^0.13.16",
     "@gits-id/forms": "^0.13.16",
     "@gits-id/tooltip": "^0.13.16",
+    "@gits-id/icon": "^0.13.16",
     "@vueuse/core": "^7.7.1",
     "vee-validate": "^4.6.1",
     "vue": "^3.2.31"

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -21,6 +21,7 @@
     "@gits-id/theme": "^0.13.16",
     "@gits-id/tooltip": "^0.13.16",
     "@gits-id/utils": "^0.13.0",
+    "@gits-id/icon": "^0.13.16",
     "vue": "^3.2.31"
   },
   "devDependencies": {

--- a/packages/select/package.json
+++ b/packages/select/package.json
@@ -33,10 +33,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/select.umd.js",
   "unpkg": "dist/select.iife.js",
   "jsdelivr": "dist/select.iife.js",

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -27,10 +27,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/services.umd.js",
   "unpkg": "dist/services.iife.js",
   "jsdelivr": "dist/services.iife.js",

--- a/packages/stats/package.json
+++ b/packages/stats/package.json
@@ -33,10 +33,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/stats.umd.js",
   "unpkg": "dist/stats.iife.js",
   "jsdelivr": "dist/stats.iife.js",

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -32,10 +32,6 @@
     "vite": "^3.0.0",
     "vitest": "^0.12.4"
   },
-  "peerDependencies": {
-    "@heroicons/vue": "^1.0.6",
-    "@iconify/vue": "^3.2.1"
-  },
   "main": "dist/table.umd.js",
   "unpkg": "dist/table.iife.js",
   "jsdelivr": "dist/table.iife.js",


### PR DESCRIPTION
- Remove remaining iconify and heroicons defined in peerdeps. I missed some on my last PR.
- Fix issue with packages not being defined in `package.json`. 