### PR TITLE
feat(multiselect): set some elements as slot to promote customization

### DIFF
--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -287,6 +287,42 @@ Add custom element after option list
 
 <LivePreview src="components-multiselect--append-item" />
 
+### item.label
+Allows custom render for option item.
+
+Slot Props
+
+| Prop        | Value      | Description                                    |
+|-------------|------------|------------------------------------------------|
+| `index`    | `number`    | Index of the current selection                 |
+| `item`     | `any`       | Current selected item at given index           |
+| `value`    | `string`    | Label of selected item.                        |
+| `iSelected` | `boolean`  | A flag to indicate if it is currently selected |
+
+```vue
+<v-multi-select>
+    <template v-slot:item.label="{item, index}">
+      <div class="flex gap-4">
+        <div>
+          <img :src="item.picture" class="rounded-full w-[60px]"/>
+        </div>
+    
+        <div class="flex-1 overflow-hidden">
+          <div class="font-bold text-gray-600">
+            {{ item.name?.first }} {{item.name?.last}}
+          </div>
+          <div class="text-sm text-gray-500">
+            {{item.email}}<br/>
+            {{item.nat}}
+          </div>
+        </div>
+      </div>
+    </template>
+</v-multi-select>
+```
+
+<LivePreview src="components-multiselect--custom-item-label" />
+
 
 ## CSS Variables
 

--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -227,6 +227,34 @@ Slot Props
 
 <LivePreview src="components-multiselect--custom-max-selection" />
 
+### select-all
+Allows custom render for select all option. This will only be run if [`selectAll`](#selectAll) props is set to valid value.
+
+Slot Props
+
+| Prop        | Value      | Description                                             |
+|-------------|------------|---------------------------------------------------------|
+| `iSelected` | `boolean`  | A flag to indicate if all options is currently selected |
+| `onClick`   | `function` | Callback to toggle select all state                     |
+
+```vue
+<v-multi-select
+  select-all
+>
+    <template v-slot:select-all='{onClick, isSelected}'>
+      <div class="p-4 bg-white sticky left-0 top-0 hover:bg-[gainsboro] border-b-[1px] border-b-grey-500"
+           style="z-index: 1;"
+           @click='onClick'
+      >
+        {{isSelected ? ' v ' : ''}}
+        Select All
+      </div>
+    </template>
+</v-multi-select>
+```
+
+<LivePreview src="components-multiselect--custom-select-all" />
+
 
 ## CSS Variables
 

--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -255,6 +255,38 @@ Slot Props
 
 <LivePreview src="components-multiselect--custom-select-all" />
 
+### prepend.item
+Add custom element before option list
+
+```vue
+<v-multi-select
+>
+    <template #prepend.item>
+      <div class='text-center italic py-4 px-2'>
+        What genre you often listen to? 🎵 🎧
+      </div>
+    </template>
+</v-multi-select>
+```
+
+<LivePreview src="components-multiselect--prepend-item" />
+
+### append.item
+Add custom element after option list
+
+```vue
+<v-multi-select
+>
+    <template #append.item>
+      <div class='text-center italic'>
+        🔥 This is appended to item list! 🔥
+      </div>
+    </template>
+</v-multi-select>
+```
+
+<LivePreview src="components-multiselect--append-item" />
+
 
 ## CSS Variables
 

--- a/docs/components/multi-select.md
+++ b/docs/components/multi-select.md
@@ -182,7 +182,51 @@ None
 
 ## Slots
 
-None
+### selection
+Allow customized selection rendering. Will only be run when there is selected value.
+If [`maxBadge`](#maxBadge) is set to valid value, it will only be run for items within the set limit. 
+
+Slot Props
+
+| Prop       | Value       | Description                           |
+|------------|-------------|---------------------------------------|
+| `index`    | `number`    | Index of the current selection        |
+| `item`     | `any`       | Current selected item at given index  |
+| `value`    | `string`    | Label of selected item.               |
+| `onRemove` | `function`  | Callback to remove selected item      |
+
+```vue
+<v-multi-select>
+    <template v-slot:selection='{index, value, onRemove}'>
+      <span class='font-bold' @click='onRemove'>{{index > 0 ? ',' :''}}{{value}}</span>
+    </template>
+</v-multi-select>
+```
+
+<LivePreview src="components-multiselect--custom-selection" />
+
+
+### max-selection
+Allows customized rendering for max-selection rendering. This will only be run if [`maxBadge`](#maxBadge) props is set to valid value.
+
+Slot Props
+
+| Prop       | Value       | Description                           |
+|------------|-------------|---------------------------------------|
+| `length`   | `number`    | Number of selected items being hidden |
+
+```vue
+<v-multi-select
+  :max-badge='2'
+>
+    <template v-slot:max-selection='{length}'>
+      <span>{{length}} more (hover me)</span>
+    </template>
+</v-multi-select>
+```
+
+<LivePreview src="components-multiselect--custom-max-selection" />
+
 
 ## CSS Variables
 

--- a/packages/multi-select/src/VMultiSelect.stories.js
+++ b/packages/multi-select/src/VMultiSelect.stories.js
@@ -340,6 +340,88 @@ export const CustomSelectAll = (args) => ({
 `,
 });
 
+export const PrependItem = (args) => ({
+  components: {VMultiSelect},
+  setup() {
+    const schema = object({
+      genre: array().required().min(1).label('Genre'),
+    });
+
+    const {handleSubmit, resetForm, values} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        genre: [...genreItems]
+      }
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    const genres = ref(genreItems);
+
+    return {onSubmit, resetForm, values, genres};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+      <v-multi-select
+        name="genre"
+        label="Genre"
+        placeholder="Choose your prefered genres"
+        select-all
+        :items="genres"
+      >
+        <template #prepend.item>
+          <div class='text-center italic py-4 px-2'>
+            What genre you often listen to? 🎵 🎧
+          </div>
+        </template>
+      </v-multi-select>
+    </form>
+`,
+});
+
+export const AppendItem = (args) => ({
+  components: {VMultiSelect},
+  setup() {
+    const schema = object({
+      genre: array().required().min(1).label('Genre'),
+    });
+
+    const {handleSubmit, resetForm, values} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        genre: [...genreItems]
+      }
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    const genres = ref(genreItems);
+
+    return {onSubmit, resetForm, values, genres};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+      <v-multi-select
+        name="genre"
+        label="Genre"
+        placeholder="Choose your prefered genres"
+        select-all
+        :items="genres"
+      >
+        <template #append.item>
+          <div class='text-center italic'>
+            🔥 This is appended to item list! 🔥
+          </div>
+        </template>
+      </v-multi-select>
+    </form>
+`,
+});
+
 export const CssVars = () => ({
   components: {
     VMultiSelect,

--- a/packages/multi-select/src/VMultiSelect.stories.js
+++ b/packages/multi-select/src/VMultiSelect.stories.js
@@ -295,6 +295,51 @@ export const CustomMaxSelection = (args) => ({
 `,
 });
 
+export const CustomSelectAll = (args) => ({
+  components: {VMultiSelect},
+  setup() {
+    const schema = object({
+      genre: array().required().min(1).label('Genre'),
+    });
+
+    const {handleSubmit, resetForm, values} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        genre: [...genreItems]
+      }
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    const genres = ref(genreItems);
+
+    return {onSubmit, resetForm, values, genres};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+      <v-multi-select
+        name="genre"
+        label="Genre"
+        placeholder="Choose your prefered genres"
+        select-all
+        :items="genres"
+      >
+        <template v-slot:select-all='{onClick, isSelected}'>
+          <div class="px-4 py-8 bg-white font-bold sticky left-0 -top-[0.25rem] hover:bg-[gainsboro] border-b-[1px] border-b-grey-500" 
+               style="z-index: 1;"
+               @click='onClick'
+          >
+            {{isSelected ? ' v ' : ''}}
+            Select All
+          </div>
+        </template>
+      </v-multi-select>
+    </form>
+`,
+});
+
 export const CssVars = () => ({
   components: {
     VMultiSelect,

--- a/packages/multi-select/src/VMultiSelect.stories.js
+++ b/packages/multi-select/src/VMultiSelect.stories.js
@@ -2,12 +2,13 @@ import VMultiSelect from './VMultiSelect.vue';
 import VBtn from '@gits-id/button';
 import {useForm} from 'vee-validate';
 import {object, array} from 'yup';
-import {ref} from 'vue';
+import {computed, ref} from 'vue';
 
 const items = [...Array(200)].map((item, index) => ({
   value: index + 1,
   text: `Option ${index + 1}`,
 }));
+const genreItems = ['pop', 'rock', 'jazz', 'alternative','electronic', 'classical','hiphop', 'blues'].map((e) => ({text: e.toUpperCase(), value: e}))
 
 export default {
   title: 'Components/MultiSelect',
@@ -206,6 +207,90 @@ export const InitialErrors = (args) => ({
         <v-btn type="button" text @click="resetForm">Reset</v-btn>
       </div>
       <pre>{{ {values} }}</pre>
+    </form>
+`,
+});
+
+export const CustomSelection = (args) => ({
+  components: {VMultiSelect},
+  setup() {
+    const schema = object({
+      genre: array().required().min(1).label('Genre'),
+    });
+
+    const {handleSubmit, resetForm, values} = useForm({
+      validationSchema: schema,
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    const genres = ref(genreItems);
+
+    const moreText = computed(() => {
+      return values.genre.slice(3).map((e) => e.text).join(', ');
+    })
+
+    return {onSubmit, resetForm, values, genres, moreText};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+      <v-multi-select
+        name="genre"
+        label="Genre"
+        placeholder="Choose your prefered genres"
+        :max-badge='3'
+        :items="genres"
+      >
+        <template v-slot:selection='{index, value, onRemove}'>
+          <span class='font-bold' @click='onRemove'>{{value}}{{index < (values.genre.length-1) && values.genre.length > 0 ? ',' :''}}</span>
+        </template>
+      </v-multi-select>
+    </form>
+`,
+});
+
+export const CustomMaxSelection = (args) => ({
+  components: {VMultiSelect},
+  setup() {
+    const schema = object({
+      genre: array().required().min(1).label('Genre'),
+    });
+
+    const {handleSubmit, resetForm, values} = useForm({
+      validationSchema: schema,
+      initialValues: {
+        genre: [...genreItems]
+      }
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    const genres = ref(genreItems);
+    const maxItem = ref(2);
+
+    const moreText = computed(() => {
+      return values.genre.slice(maxItem.value).map((e) => e.text).join(', ');
+    })
+
+    return {onSubmit, resetForm, values, genres, maxItem, moreText};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+      <v-multi-select
+        name="genre"
+        label="Genre"
+        placeholder="Choose your prefered genres"
+        :max-badge='maxItem'
+        :items="genres"
+      >
+        <template v-slot:max-selection='{length}'>
+          <span :title='moreText'>{{length}} more (hover me)</span>
+        </template>
+      </v-multi-select>
     </form>
 `,
 });

--- a/packages/multi-select/src/VMultiSelect.stories.js
+++ b/packages/multi-select/src/VMultiSelect.stories.js
@@ -9,6 +9,118 @@ const items = [...Array(200)].map((item, index) => ({
   text: `Option ${index + 1}`,
 }));
 const genreItems = ['pop', 'rock', 'jazz', 'alternative','electronic', 'classical','hiphop', 'blues'].map((e) => ({text: e.toUpperCase(), value: e}))
+const userItems = [
+  {
+    "name": {
+      "title": "Miss",
+      "first": "Laura",
+      "last": "Woods"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/88.jpg",
+    "country": "Ireland",
+    "email": "laura.woods@example.com",
+    "nat": "IE"
+  },
+  {
+    "name": {
+      "title": "Mr",
+      "first": "Marten",
+      "last": "Faber"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/men/1.jpg",
+    "country": "Germany",
+    "email": "marten.faber@example.com",
+    "nat": "DE"
+  },
+  {
+    "name": {
+      "title": "Miss",
+      "first": "Christy",
+      "last": "Diaz"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/53.jpg",
+    "country": "Australia",
+    "email": "christy.diaz@example.com",
+    "nat": "AU"
+  },
+  {
+    "name": {
+      "title": "Mrs",
+      "first": "Naomi",
+      "last": "Ortiz"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/10.jpg",
+    "country": "Australia",
+    "email": "naomi.ortiz@example.com",
+    "nat": "AU"
+  },
+  {
+    "name": {
+      "title": "Miss",
+      "first": "Emeline",
+      "last": "Carpentier"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/95.jpg",
+    "country": "France",
+    "email": "emeline.carpentier@example.com",
+    "nat": "FR"
+  },
+  {
+    "name": {
+      "title": "Mr",
+      "first": "Jun",
+      "last": "Hansen"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/men/1.jpg",
+    "country": "Netherlands",
+    "email": "jun.hansen@example.com",
+    "nat": "NL"
+  },
+  {
+    "name": {
+      "title": "Miss",
+      "first": "Carla",
+      "last": "Fernández"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/52.jpg",
+    "country": "Spain",
+    "email": "carla.fernandez@example.com",
+    "nat": "ES"
+  },
+  {
+    "name": {
+      "title": "Ms",
+      "first": "Vandana",
+      "last": "Dalvi"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/16.jpg",
+    "country": "India",
+    "email": "vandana.dalvi@example.com",
+    "nat": "IN"
+  },
+  {
+    "name": {
+      "title": "Mrs",
+      "first": "Nurdan",
+      "last": "Köybaşı"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/women/86.jpg",
+    "country": "Turkey",
+    "email": "nurdan.koybasi@example.com",
+    "nat": "TR"
+  },
+  {
+    "name": {
+      "title": "Mr",
+      "first": "Marc",
+      "last": "Shaw"
+    },
+    "picture": "https://randomuser.me/api/portraits/thumb/men/92.jpg",
+    "country": "United States",
+    "email": "marc.shaw@example.com",
+    "nat": "US"
+  }
+];
 
 export default {
   title: 'Components/MultiSelect',
@@ -415,6 +527,58 @@ export const AppendItem = (args) => ({
         <template #append.item>
           <div class='text-center italic'>
             🔥 This is appended to item list! 🔥
+          </div>
+        </template>
+      </v-multi-select>
+    </form>
+`,
+});
+
+export const CustomItemLabel = (args) => ({
+  components: {VMultiSelect},
+  setup() {
+    const schema = object({
+      genre: array().required().min(1).label('Genre'),
+    });
+
+    const {handleSubmit, resetForm, values} = useForm({
+      validationSchema: schema,
+    });
+
+    const onSubmit = handleSubmit((values) => {
+      alert(JSON.stringify(values));
+    });
+
+    const genres = ref(userItems);
+
+    return {onSubmit, resetForm, values, genres};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+      <v-multi-select
+        name="assignee"
+        label="Assign To"
+        placeholder="Choose users"
+        item-text="email"
+        item-value="email"
+        select-all
+        :items="genres"
+      >
+        <template v-slot:item.label="{item}">
+          <div class="flex gap-4">
+            <div>
+              <img :src="item.picture" class="rounded-full w-[60px]"/>
+            </div>
+            
+            <div class="flex-1 overflow-hidden">
+              <div class="font-bold text-gray-600">
+                {{ item.name?.first }} {{item.name?.last}}
+              </div>
+              <div class="text-sm text-gray-500">
+                {{item.email}}<br/>
+                {{item.nat}}
+              </div>
+            </div>
           </div>
         </template>
       </v-multi-select>

--- a/packages/multi-select/src/VMultiSelect.vue
+++ b/packages/multi-select/src/VMultiSelect.vue
@@ -400,21 +400,32 @@ watch(
         >
           <div class="flex-1 space-y-2">
             <div v-if="selected.length" class="v-multi-select-badges">
-              <v-badge
-                v-for="sItem in badges"
-                :key="sItem.value"
-                :color="badgeColor"
-                dismissable
-                class="truncate"
-                :class="badgeClass"
-                @dismiss="deselect(sItem)"
-                v-bind="badgeProps"
-              >
-                {{ sItem[itemText] }}
-              </v-badge>
-              <v-badge v-if="maxBadge > 0 && selected.length > maxBadge" small>
-                {{ selected.length - maxBadge }} more
-              </v-badge>
+              <template v-for="(sItem, index) in badges" :key="sItem.value">
+                <slot name="selection"
+                      :index="index"
+                      :item="sItem"
+                      :value="sItem[itemText]"
+                      :onRemove="() => deselect(sItem)">
+                  <v-badge
+                    :color="badgeColor"
+                    dismissable
+                    class="truncate"
+                    :class="badgeClass"
+                    @dismiss="deselect(sItem)"
+                    v-bind="badgeProps"
+                  >
+                    {{ sItem[itemText] }}
+                  </v-badge>
+                </slot>
+              </template>
+
+              <template v-if="maxBadge > 0 && selected.length > maxBadge">
+                <slot name="max-selection">
+                  <v-badge small>
+                    {{ selected.length - maxBadge }} more
+                  </v-badge>
+                </slot>
+              </template>
             </div>
             <input
               :id="id"

--- a/packages/multi-select/src/VMultiSelect.vue
+++ b/packages/multi-select/src/VMultiSelect.vue
@@ -548,7 +548,7 @@ watch(
                     />
                   </div>
                   <div class="v-multi-select-item-text">
-                    {{ item[itemText] }}
+                    <slot  name="item.label" :index="index" :item="item" :value="item[itemText]" :isSelected='isSelected(item, index)'>{{ item[itemText] }}</slot>
                   </div>
                 </div>
               </template>

--- a/packages/multi-select/src/VMultiSelect.vue
+++ b/packages/multi-select/src/VMultiSelect.vue
@@ -515,6 +515,8 @@ watch(
                 </slot>
               </template>
 
+              <slot name='prepend.item' />
+
               <template
                 v-for="(item, index) in filteredItems"
                 :key="item.value"
@@ -550,6 +552,8 @@ watch(
                   </div>
                 </div>
               </template>
+
+              <slot name='append.item' />
             </template>
             <div
               v-else

--- a/packages/multi-select/src/VMultiSelect.vue
+++ b/packages/multi-select/src/VMultiSelect.vue
@@ -427,6 +427,7 @@ watch(
                 </slot>
               </template>
             </div>
+
             <input
               :id="id"
               type="text"
@@ -492,25 +493,28 @@ watch(
             </div>
             <template v-else-if="filteredItems.length">
               <template v-if="selectAll">
-                <div class="v-multi-select-item" @click="toggleSelectAll">
-                  <div
-                    :class="[
+                <slot name="select-all" :onClick="toggleSelectAll" :isSelected='isAllSelected'>
+                  <div class="v-multi-select-item" @click="toggleSelectAll">
+                    <div
+                      :class="[
                       isAllSelected ? 'font-medium' : 'font-normal',
                       'block truncate',
                     ]"
-                  >
-                    {{ isAllSelected ? 'Deselect All' : 'Select All' }}
+                    >
+                      {{ isAllSelected ? 'Deselect All' : 'Select All' }}
+                    </div>
+                    <div v-if="isAllSelected" class="v-multi-select-item-check">
+                      <Icon
+                        name="heroicons:check"
+                        class="w-5 h-5"
+                        aria-hidden="true"
+                      />
+                    </div>
                   </div>
-                  <div v-if="isAllSelected" class="v-multi-select-item-check">
-                    <Icon
-                      name="heroicons:check"
-                      class="w-5 h-5"
-                      aria-hidden="true"
-                    />
-                  </div>
-                </div>
-                <div class="border-b h-1"></div>
+                  <div class="border-b h-1"></div>
+                </slot>
               </template>
+
               <template
                 v-for="(item, index) in filteredItems"
                 :key="item.value"


### PR DESCRIPTION
This PR exposes `selection`, `max-selection`, `select-all` and `option item label` content as slot to accommodate custom rendering needs. Also created two slot position in option to enable prepend and appending custom to item list.

Storybook story and vuepress docs for this component has been updated to reflect these changes.