### PR TITLE
Fix issue with scroll position in VTabs

### DIFF
--- a/packages/tabs/src/VTabs.vue
+++ b/packages/tabs/src/VTabs.vue
@@ -146,7 +146,7 @@ const onTabClicked = ({index, event}: any) => {
     const width = el.offsetWidth;
     const parentWidth = parent.offsetWidth;
     const position = left + width / 2 - parentWidth / 2;
-    el.parentElement.scrollTo({
+    (tabContent.value as HTMLElement).scrollTo({
       left: position,
     });
   } else {

--- a/packages/tabs/src/VTabs.vue
+++ b/packages/tabs/src/VTabs.vue
@@ -155,7 +155,7 @@ const onTabClicked = ({index, event}: any) => {
     } else if (nextEl && nextEl.offsetLeft > parent.offsetWidth) {
       moveNavigation(nextEl.offsetWidth);
     } else if (prevEl && prevEl.offsetLeft < el.offsetLeft) {
-      moveNavigation(-prevEl.offsetWidth);
+      moveNavigation(tabEl.offsetWidth);
     }
   }
 };


### PR DESCRIPTION
This fixes scroll issue happening in VTabs when `centerActive` is set to `true` or when `showArrows` is set to `true`.