### PR TITLE
[VTabs] fix slider issue and slot improvement

### DIFF
--- a/docs/components/tabs.md
+++ b/docs/components/tabs.md
@@ -19,6 +19,7 @@ const items = createItems();
 ```
 
 ```vue
+
 <template>
   <VTabs :items="items" />
 </template>
@@ -27,10 +28,13 @@ const items = createItems();
 <LivePreview src="components-tabs--default" />
 
 ::: info
-The `VTabs` component is registered globally when you install with `@gits-id/ui`. So you don't need to import it manually.
+The `VTabs` component is registered globally when you install with `@gits-id/ui`. So you don't need to import it
+manually.
 :::
 
 ### `v-model`
+
+Use `v-model `to set selected tab.
 
 ```vue
 <script setup lang="ts">
@@ -46,21 +50,25 @@ const selectedTab = ref(0);
 
 ### Custom Active Class
 
+Define custom classes to apply when tab is active (`active-class`), inactive (`inactive-class`). Or add common custom class for tabs using `default-class`.
+
 ```vue
 <template>
   <VTabs
     :items="items"
-    default-class="!rounded-lg"
-    inactive-class="hover:bg-success-50 hover:!text-success-600"
-    active-class="bg-success-50 rounded-t text-success-600 font-semibold"
+    default-class='!rounded-lg'
+    inactive-class='hover:bg-success-50 hover:!text-success-600'
+    active-class='bg-success-50 rounded-t text-success-600 font-semibold'
     hide-slider
   />
 </template>
 ```
 
-<LivePreview src="components-tabs--custom-active-class"  />
+<LivePreview src="components-tabs--custom-active-class" height='150' />
 
 ### Show Arrow
+
+Use `showArrow` to enable  arrows to scroll the tab list. Only works if the list is scrollable.
 
 ```vue
 <template>
@@ -68,9 +76,11 @@ const selectedTab = ref(0);
 </template>
 ```
 
-<LivePreview src="components-tabs--show-arrows" />
+<LivePreview src="components-tabs--show-arrows" height='150' />
 
 ### Center Active
+
+Use `centerActive` to allow the active tab to be position as at the center if possible. Works well when the list is scrollable.
 
 ```vue
 <template>
@@ -78,9 +88,11 @@ const selectedTab = ref(0);
 </template>
 ```
 
-<LivePreview src="components-tabs--center-active" />
+<LivePreview src="components-tabs--center-active" height='150'/>
 
 ### Vertical
+
+Use `vertical` to render the tabs vertically.
 
 ```vue
 <template>
@@ -88,15 +100,17 @@ const selectedTab = ref(0);
 </template>
 ```
 
-<LivePreview src="components-tabs--vertical" />
+<LivePreview src="components-tabs--vertical" height='150' />
 
 ### Tabs with Card
 
+Use `VTabs` as header in a `VCard` component.
+
 ```vue
 <template>
-  <VCard body-class="!p-0" hide-header hide-footer>
+  <VCard body-class='!p-0' hide-header hide-footer>
     <VTabs v-model="tab" />
-    <div class="px-4 py-2">Tab Content {{ tab }}</div>
+    <div class='px-4 py-2'>Tab Content {{ tab }}</div>
   </VCard>
 </template>
 ```
@@ -104,6 +118,8 @@ const selectedTab = ref(0);
 <LivePreview src="components-tabs--tabs-with-card" />
 
 ### Custom Style
+
+Override CSS variables for `VTabs` inline through `style` prop;
 
 ```vue
 <template>
@@ -124,7 +140,7 @@ const selectedTab = ref(0);
 </template>
 ```
 
-<LivePreview src="components-tabs--custom-style" />
+<LivePreview src="components-tabs--custom-style" height='150' />
 
 ### Removeable
 
@@ -138,24 +154,24 @@ const selectedTab = ref(0);
 
 ## Props
 
-| Name                                          | Type                                                                                | Default     |
-| --------------------------------------------- | ----------------------------------------------------------------------------------- | ----------- |
-| [`modelValue`](#modelValue)                   | `Number or String`                                                                  | `0`         |
-| [`items`](#items)                             | `Array<TabItem[]>`                                                                  | `[]`        |
-| [`itemText`](#itemText)                       | `String`                                                                            | `'text'`    |
-| [`color`](#color)                             | `String \| 'primary' \| 'secondary' \| 'info' \| 'warning' \| 'success' \| 'error'` | `'primary'` |
-| [`showArrows`](#showArrows)                   | `Boolean`                                                                           | `false`     |
-| [`centerActive`](#centerActive)               | `Boolean`                                                                           | `false`     |
-| [`removeable`](#removeable)                   | `Boolean`                                                                           | `false`     |
-| [`vertical`](#vertical)                       | `Boolean`                                                                           | `false`     |
-| [`defaultWrapperClass`](#defaultWrapperClass) | `String`                                                                            | `''`        |
-| [`wrapperClass`](#wrapperClass)               | `String`                                                                            | `''`        |
-| [`hideSlider`](#hideSlider)                   | `Boolean`                                                                           | `false`     |
-| [`activeClass`](#activeClass)                 | `String`                                                                            | `''`        |
-| [`inactiveClass`](#inactiveClass)             | `String`                                                                            | `''`        |
-| [`defaultClass`](#defaultClass)               | `String`                                                                            | `''`        |
-| [`contentClass`](#contentClass)               | `String`                                                                            | `''`        |
-| [`sliderClass`](#sliderClass)                 | `String`                                                                            | `''`        |
+| Name                                          | Type                                                                                            | Default     |
+|-----------------------------------------------|-------------------------------------------------------------------------------------------------|-------------|
+| [`modelValue`](#modelValue)                   | `Number or String`                                                                              | `0`         |
+| [`items`](#items)                             | `Array<TabItem[]>`                                                                              | `[]`        |
+| [`itemText`](#itemText)                       | `String`                                                                                        | `'text'`    |
+| [`color`](#color)                             | `'primary'` &vert; `'secondary'` &vert; `'info'` &vert; `'warning'` &vert; `'success'` &vert; `'error'` | `'primary'` |
+| [`showArrows`](#showArrows)                   | `Boolean`                                                                                       | `false`     |
+| [`centerActive`](#centerActive)               | `Boolean`                                                                                       | `false`     |
+| [`removeable`](#removeable)                   | `Boolean`                                                                                       | `false`     |
+| [`vertical`](#vertical)                       | `Boolean`                                                                                       | `false`     |
+| [`defaultWrapperClass`](#defaultWrapperClass) | `String`                                                                                        | `''`        |
+| [`wrapperClass`](#wrapperClass)               | `String`                                                                                        | `''`        |
+| [`hideSlider`](#hideSlider)                   | `Boolean`                                                                                       | `false`     |
+| [`activeClass`](#activeClass)                 | `String`                                                                                        | `''`        |
+| [`inactiveClass`](#inactiveClass)             | `String`                                                                                        | `''`        |
+| [`defaultClass`](#defaultClass)               | `String`                                                                                        | `''`        |
+| [`contentClass`](#contentClass)               | `String`                                                                                        | `''`        |
+| [`sliderClass`](#sliderClass)                 | `String`                                                                                        | `''`        |
 
 ## Events
 
@@ -214,7 +230,7 @@ const onChange = (value: number) => console.log(value);
 ```vue
 <script setup lang="ts">
 import {ref} from 'vue';
-improt {useToast} from '@/composables';
+import {useToast} from '@/composables';
 
 const items = ref([
   {
@@ -245,64 +261,146 @@ const onRemove = (index: number) => {
 
 ### `default`
 
+Define custom tab items rendering
+
+Slot Props
+
+| Prop          | Value      | Description                |
+|---------------|------------|----------------------------|
+| `onClick`     | `function` | Index of current tab       |
+| `registerRef` | `function` | Current tab original value |
+
 ```vue
-<template>
-  <VTabs>
-    <VTabsSlider />
-    <VTab>Tab 1</VTab>
-    <VTab>Tab 2</VTab>
-    <VTab>Tab 3</VTab>
-  </VTabs>
+<VTabs>
+<template v-slot:default="{onClick, registerRef, }">
+  <VTab
+    v-bind="item"
+    v-for="(item, index) in items"
+    :key="index"
+    :index="index"
+    :get-ref="registerRef"
+    :active="index === activeTab"
+    @click="onClick"
+  >
+    <div class="inline-block">
+      {{ item.text }} {{ item.icon }}
+
+      <span v-if="tab  === index" class='text-red-700' style='font-size: 10px; vertical-align: middle;'>
+        {{ index }}
+      </span>
+    </div>
+  </VTab>
 </template>
+</VTabs>
 ```
+
+<LivePreview src="components-tabs--custom-tab" height='200' />
+
+### `item`
+
+Define custom content for the tab.
+
+Slot Props
+
+| Prop     | Value     | Description                              |
+|----------|-----------|------------------------------------------|
+| `index`  | `number`  | Index of current tab                     |
+| `item`   | `any`     | Current tab original value               |
+| `value`  | `any`     | Current tab label                        |
+| `active` | `boolean` | Indication whether current tab is active |
+
+```vue
+<VTabs>
+<template v-slot:item="{index, item, value, active}">
+  <div class="inline-block">
+    {{ value }} {{ item.icon }}
+
+    <span v-if="active" class='text-red-700' style='font-size: 10px; vertical-align: middle;'>
+        {{ index }}
+      </span>
+  </div>
+</template>
+</VTabs>
+
+```
+
+<LivePreview src="components-tabs--custom-tab-content" height="200" />
 
 ### `previous`
 
+Define custom content for the previous arrow. Works when `showArrows` is set to `true`.
+
+Slot Props
+
+| Prop      | Value      | Description                     |
+|-----------|------------|---------------------------------|
+| `onClick` | `function` | Callback to handle click action |
+
 ```vue
-<template>
-  <VTabs>
-    <template #previous>
-      <VBtn prefix-icon="ri:arrow-left-s-line" />
-    </template>
-  </VTabs>
+<VTabs>
+<template v-slot:previous="{onClick}">
+  <VBtn prefix-icon="ri:arrow-left-s-line" class='mr-2' @click="onClick" />
 </template>
+</VTabs>
 ```
+
+<LivePreview src="components-tabs--previous" height="200" />
 
 ### `next`
 
+Define custom content for the next arrow. Works when `showArrows` is set to `true`.
+
+Slot Props
+
+| Prop      | Value      | Description                     |
+|-----------|------------|---------------------------------|
+| `onClick` | `function` | Callback to handle click action |
+
 ```vue
-<template>
-  <VTabs>
-    <template #next>
-      <VBtn prefix-icon="ri:arrow-right-s-line" />
-    </template>
-  </VTabs>
+<VTabs>
+<template v-slot:next="{onClick}">
+  <VBtn prefix-icon="ri:arrow-right-s-line" class='mr-2' @click="onClick" />
 </template>
+</VTabs>
 ```
+
+<LivePreview src="components-tabs--next" height="200" />
 
 ### `prepend`
 
+Add an item to the start of the tab list
+
 ```vue
 <template>
-  <VTabs :items="items">
+  <VTabs>
     <template #prepend>
-      <VTab>Prepended Item</VTab>
+      <div class='bg-[yellow] whitespace-nowrap uppercase p-3 mr-2 rounded-full'>
+        🎒
+      </div>
     </template>
   </VTabs>
 </template>
 ```
+
+<LivePreview src="components-tabs--prepend" height="200" />
 
 ### `append`
 
+Add an item to the end of the tab list
+
 ```vue
 <template>
-  <VTabs :items="items">
+  <VTabs>
     <template #append>
-      <VTab>Appended Item</VTab>
+      <button title="See? I've been appended!">
+        ❓
+      </button>
     </template>
   </VTabs>
 </template>
 ```
+
+<LivePreview src="components-tabs--append" height="200" />
 
 ## CSS Variables
 

--- a/packages/tabs/src/VTab.vue
+++ b/packages/tabs/src/VTab.vue
@@ -109,7 +109,7 @@ const isActive = computed(() => {
       icon
       fab
       type="button"
-      @click="remove(index)"
+      @click.prevent.stop="remove(index)"
     >
       <Icon
         :name="icon"

--- a/packages/tabs/src/VTab.vue
+++ b/packages/tabs/src/VTab.vue
@@ -74,7 +74,8 @@ const setRef = (el: any) => {
 };
 
 const isActive = computed(() => {
-  return inject('activeTab', 0) === index.value || props.active;
+  const injected = inject('activeTab', {value: 0})?.value;
+  return injected === index.value || active.value;
 });
 </script>
 
@@ -82,7 +83,7 @@ const isActive = computed(() => {
   <button
     type="button"
     role="tab"
-    :id="`tab-item-${index}`"
+    :id='`tab-item-${index}`'
     :ref="setRef"
     class="v-tabs-item"
     :class="[
@@ -93,16 +94,14 @@ const isActive = computed(() => {
       isActive ? activeClass : inactiveClass,
       vertical ? 'v-tabs-item--vertical' : '',
     ]"
+    @click='onClick(index, $event)'
+    @mouseover="hovered = index"
+    @mouseout='hovered = -1'
   >
-    <div
-      @click="onClick(index, $event)"
-      @mouseover="hovered = index"
-      @mouseout="hovered = -1"
-    >
-      <slot />
-    </div>
+    <slot />
+
     <v-btn
-      v-if="active && removeable"
+      v-if='active && removeable'
       class="v-tabs-item-remove"
       color="error"
       size="sm"

--- a/packages/tabs/src/VTabs.stories.ts
+++ b/packages/tabs/src/VTabs.stories.ts
@@ -1,9 +1,10 @@
 import VTabs from './VTabs.vue';
 import VTab from './VTab.vue';
-import VTabsSlider from './VTabsSlider.vue';
+import VBtn from '@gits-id/button';
 import VCard from '@gits-id/card';
 import {ref} from 'vue';
 import {Story} from '@storybook/vue3';
+import VTabsSlider from './VTabsSlider.vue';
 
 function createItems(len = 20, additionalItem = {}) {
   return [...Array(20)].map((v, k) => ({
@@ -13,6 +14,7 @@ function createItems(len = 20, additionalItem = {}) {
 }
 
 export default {
+  components: {VTabsSlider},
   title: 'Components/Tabs',
   component: VTabs,
   argTypes: {},
@@ -27,7 +29,7 @@ const Template: Story<{}> = (args) => ({
   setup() {
     return {args};
   },
-  template: `<v-tabs v-bind='args'/>`,
+  template: `<v-tabs v-bind="args"/>`,
 });
 
 export const Default = Template.bind({});
@@ -46,12 +48,12 @@ export const Colors: Story<{}> = (args) => ({
     return {args};
   },
   template: `
-    <v-tabs v-bind='args' />
-    <v-tabs v-bind='args' color="secondary" />
-    <v-tabs v-bind='args' color="info" />
-    <v-tabs v-bind='args' color="warning" />
-    <v-tabs v-bind='args' color="success" />
-    <v-tabs v-bind='args' color="error" />
+    <v-tabs v-bind="args" />
+    <v-tabs v-bind="args" color="secondary" />
+    <v-tabs v-bind="args" color="info" />
+    <v-tabs v-bind="args" color="warning" />
+    <v-tabs v-bind="args" color="success" />
+    <v-tabs v-bind="args" color="error" />
   `,
 });
 Colors.parameters = {
@@ -59,11 +61,11 @@ Colors.parameters = {
     source: {
       code: `
 <v-tabs :items="items" color="secondary" />
-<v-tabs v-bind='args' color="secondary" />
-<v-tabs v-bind='args' color="info" />
-<v-tabs v-bind='args' color="warning" />
-<v-tabs v-bind='args' color="success" />
-<v-tabs v-bind='args' color="error" />
+<v-tabs v-bind="args" color="secondary" />
+<v-tabs v-bind="args" color="info" />
+<v-tabs v-bind="args" color="warning" />
+<v-tabs v-bind="args" color="success" />
+<v-tabs v-bind="args" color="error" />
       `,
     },
   },
@@ -190,5 +192,288 @@ export const Removeable: Story<{}> = (args) => ({
       v-bind="args"
       removeable
     />
+  `,
+});
+
+export const CustomTabContent: Story<{}> = (args) => ({
+  components: {VTabs, VBtn},
+  setup() {
+    const tab = ref(0);
+    const simple = ref(false);
+    const items = ref([
+      {
+        text: 'Fruits',
+        icon: '🥑',
+      },
+      {
+        text: 'Meat',
+        icon: '🥩',
+      },
+      {
+        text: 'Veggies',
+        icon: '🥦',
+      },
+      {
+        text: 'Bread',
+        icon: '🍞',
+      },
+      {
+        text: 'Fish',
+        icon: '🐟',
+      },
+    ]);
+
+    return {args, items, tab, simple};
+  },
+  template: `
+    <VBtn @click='simple = !simple;'>
+      Click me to toggle simplified tabs view
+    </VBtn>
+
+    <VTabs
+      v-bind="args"
+      v-model="tab"
+      :items="items"
+    >
+      <template v-slot:item="{index, item, value, active}">
+        <div class="inline-block">
+          {{ !simple ? value : '' }} {{ item.icon }}
+
+          <span v-if="active" class='text-red-700' style='font-size: 10px; vertical-align: middle;'>
+            {{ index }}
+          </span>
+        </div>
+      </template>
+    </VTabs>
+  `,
+});
+
+export const CustomTab: Story<{}> = (args) => ({
+  components: {VTabs, VTab},
+  setup() {
+    const tab = ref(0);
+    const items = ref([
+      {
+        text: 'Fruits',
+        icon: '🥑',
+      },
+      {
+        text: 'Meat',
+        icon: '🥩',
+      },
+      {
+        text: 'Veggies',
+        icon: '🥦',
+      },
+      {
+        text: 'Bread',
+        icon: '🍞',
+      },
+      {
+        text: 'Fish',
+        icon: '🐟',
+      },
+    ]);
+
+    return {args, items, tab};
+  },
+  template: `
+    <VTabs
+      v-model="tab"
+    >
+      <template v-slot:default="{onClick, registerRef, }">
+        <VTab
+          v-bind="item"
+          v-for="(item, index) in items"
+          :key="index"
+          :index="index"
+          :get-ref="registerRef"
+          class="TEST_CLASS"
+          @click="onClick"
+        >
+          <div class="inline-block">
+            {{ item.text }} {{ item.icon }}
+
+            <span v-if="tab  === index" class='text-red-700' style='font-size: 10px; vertical-align: middle;'>
+            {{ index }}
+          </span>
+          </div>
+        </VTab>
+      </template>
+    </VTabs>
+  `,
+});
+
+export const Prepend: Story<{}> = (args) => ({
+  components: {VTabs, VTab},
+  setup() {
+    const tab = ref(0);
+    const items = ref([
+      {
+        text: 'Fruits',
+        icon: '🥑',
+      },
+      {
+        text: 'Meat',
+        icon: '🥩',
+      },
+      {
+        text: 'Veggies',
+        icon: '🥦',
+      },
+      {
+        text: 'Bread',
+        icon: '🍞',
+      },
+      {
+        text: 'Fish',
+        icon: '🐟',
+      },
+    ]);
+
+    return {args, items, tab};
+  },
+  template: `
+    <VTabs
+      v-bind="args"
+      v-model="tab"
+      :items="items"
+    >
+    <template #prepend>
+      <div class="bg-[yellow] whitespace-nowrap uppercase p-3 mr-2 rounded-full">
+        🎒
+      </div>
+    </template>
+    </VTabs>
+  `,
+});
+
+export const Append: Story<{}> = (args) => ({
+  components: {VTabs, VTab},
+  setup() {
+    const tab = ref(0);
+    const items = ref([
+      {
+        text: 'Fruits',
+        icon: '🥑',
+      },
+      {
+        text: 'Meat',
+        icon: '🥩',
+      },
+      {
+        text: 'Veggies',
+        icon: '🥦',
+      },
+      {
+        text: 'Bread',
+        icon: '🍞',
+      },
+      {
+        text: 'Fish',
+        icon: '🐟',
+      },
+    ]);
+
+    return {args, items, tab};
+  },
+  template: `
+    <VTabs
+      v-bind="args"
+      v-model="tab"
+      :items="items"
+    >
+    <template #append>
+      <button title="See? I've been appended!">
+        ❓
+      </button>
+    </template>
+    </VTabs>
+  `,
+});
+
+export const Previous: Story<{}> = (args) => ({
+  components: {VTabs, VBtn},
+  setup() {
+    const tab = ref(0);
+    const items = ref([
+      {
+        text: 'Fruits',
+        icon: '🥑',
+      },
+      {
+        text: 'Meat',
+        icon: '🥩',
+      },
+      {
+        text: 'Veggies',
+        icon: '🥦',
+      },
+      {
+        text: 'Bread',
+        icon: '🍞',
+      },
+      {
+        text: 'Fish',
+        icon: '🐟',
+      },
+    ]);
+
+    return {args, items, tab};
+  },
+  template: `
+    <VTabs
+      v-bind="args"
+      v-model="tab"
+      :items="items"
+      show-arrows
+    >
+    <template v-slot:previous="{onClick}">
+      <VBtn prefix-icon="ri:arrow-left-s-line" class="mr-2" @click="onClick"/>
+    </template>
+    </VTabs>
+  `,
+});
+
+export const Next: Story<{}> = (args) => ({
+  components: {VTabs, VBtn},
+  setup() {
+    const tab = ref(0);
+    const items = ref([
+      {
+        text: 'Fruits',
+        icon: '🥑',
+      },
+      {
+        text: 'Meat',
+        icon: '🥩',
+      },
+      {
+        text: 'Veggies',
+        icon: '🥦',
+      },
+      {
+        text: 'Bread',
+        icon: '🍞',
+      },
+      {
+        text: 'Fish',
+        icon: '🐟',
+      },
+    ]);
+
+    return {args, items, tab};
+  },
+  template: `
+    <VTabs
+      v-bind="args"
+      v-model="tab"
+      :items="items"
+      show-arrows
+    >
+    <template v-slot:next="{onClick}">
+      <VBtn prefix-icon="ri:arrow-right-s-line" class='ml-2' @click="onClick"/>
+    </template>
+    </VTabs>
   `,
 });


### PR DESCRIPTION
This PR fixes issue with slider not resizing when tab width changes.

Also added a new slot `item` to allow customization for tab content (label) without overriding the actual tab rendering.

Existing slots is also improved when necessary, like passing the click handler on `previous` and `next` slot so user can just pass it to let VTab do whatever it needs to do if the node was not being override by user.

Docs for the component has also been improved. Adding new stories for slot customization in storybook, and add new entry in vuepress `VTab` entry or add more description/explanation/previews to existing docs.