### PR TITLE
fix(forms): standardize label and error class

### DIFF
--- a/packages/forms/src/checkbox/VCheckbox.vue
+++ b/packages/forms/src/checkbox/VCheckbox.vue
@@ -72,6 +72,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  labelClass: {
+    type: String,
+    default: '',
+  },
 });
 
 const emit =
@@ -143,6 +147,7 @@ const handleChange = (m: any) => {
       <label
         v-if="label"
         class="v-checkbox-label"
+        :class="labelClass"
         :for="id || name"
         @mousedown.prevent="null"
       >

--- a/packages/forms/src/checkbox/VCheckbox.vue
+++ b/packages/forms/src/checkbox/VCheckbox.vue
@@ -141,6 +141,7 @@ const handleChange = (m: any) => {
         v-bind="$attrs"
       />
       <label
+        v-if="label"
         class="v-checkbox-label"
         :for="id || name"
         @mousedown.prevent="null"

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -152,6 +152,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  labelClass: {
+    type: String,
+    default: '',
+  },
 });
 
 const {
@@ -233,7 +237,7 @@ const clear = () => {
     ]"
   >
     <slot v-if="label" name="label" :v-slot="{for: id || name}">
-      <label v-if="label" :for="id || name" class="v-input-label">
+      <label v-if="label" :for="id || name" class="v-input-label" :class="labelClass">
         {{ label }}
       </label>
     </slot>

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -148,6 +148,10 @@ const props = defineProps({
     type: String as PropType<IconSize>,
     default: 'md',
   },
+  errorClass: {
+    type: String,
+    default: '',
+  },
 });
 
 const {
@@ -308,7 +312,7 @@ const clear = () => {
       </slot>
     </div>
 
-    <div v-if="errorMessage" class="v-input-error">
+    <div v-if="errorMessage" class="v-input-error" :class='errorClass'>
       {{ errorMessage }}
     </div>
   </div>

--- a/packages/forms/src/radio/VRadio.vue
+++ b/packages/forms/src/radio/VRadio.vue
@@ -68,6 +68,10 @@ const props = defineProps({
     type: String,
     default: 'disabled:text-gray-200 disabled:cursor-not-allowed',
   },
+  errorClass: {
+    type: String,
+    default: '',
+  },
 });
 
 const {modelValue, rules, label, inputClass, name, id} = toRefs(props);
@@ -129,7 +133,7 @@ watch(
         {{ label }}
       </label>
     </div>
-    <div v-if="errorMessage && !hideError" class="v-radio-error">
+    <div v-if="errorMessage && !hideError" class="v-radio-error" :class="errorClass">
       {{ errorMessage }}
     </div>
   </div>


### PR DESCRIPTION
This PR adjust:
- checkbox label behavior to match other forms label behavior, which is being hidden when label is not defined or empty.
- input and radio to have `errorClass` prop as implemented in other form inputs.
- input and checkbox to have `labelClass` prop as implemented in other form inputs