### PR TITLE
feat(stepper): add clickable prop

### DIFF
--- a/docs/components/stepper.md
+++ b/docs/components/stepper.md
@@ -66,7 +66,7 @@ Set `disableRouteActive` to `true` to base stepper active state by `modelValue` 
 - **default**: `false`
 - **required**: `false`
 
-Use `linable` to make the step item to be clickable. This works well with `disableRouteActive` set to `false`.
+Use `linkable` to make the step item to be clickable as route. This works well with `disableRouteActive` set to `false`.
 
 ```vue
 <template>
@@ -74,7 +74,24 @@ Use `linable` to make the step item to be clickable. This works well with `disab
 </template>
 ```
 
-<LivePreview src="components-stepper--linkable" height="250"/>
+### Clickable
+
+- **prop**: `clickable`
+- **type**: `boolean`
+- **default**: `false`
+- **required**: `false`
+
+Use `clickable` to allow `click` event to be emitted, allowing interaction with the step item. This is useful for when
+stepper needs to be rendered inside for example, a modal, which makes `linkable` unfeasible to be used for navigation
+through interaction with the step item.
+
+```vue
+<template>
+  <VStepper clickable />
+</template>
+```
+
+<LivePreview src="components-stepper--clickable" height="600"/>
 
 ### Vertical
 
@@ -142,14 +159,15 @@ const items = [
 
 ## Events
 
-| Name                                   | Payload            | Description                   |
-|----------------------------------------|--------------------|-------------------------------|
-| [update:modelValue](#updateModelValue) | `(value: boolean)` | Fired when step value changed |
+| Name                                   | Payload            | Description                                                                                      |
+|----------------------------------------|--------------------|--------------------------------------------------------------------------------------------------|
+| [update:modelValue](#updateModelValue) | `(value: boolean)` | Fired when step value changed                                                                    |
+| click                                  | `({item, index})`  | Fired when step item is clicked. *Only available when [`clickable`](#clickable) prop is enabled* |
 
 
 ## Manual Installation
 
-You can also install the `Alert` component individually via `@gits-id/alert` package:
+You can also install the `Stepper` component individually via `@gits-id/stepper` package:
 
 ```bash
 yarn install @gits-id/stepper

--- a/packages/steppers/src/Stepper.stories.ts
+++ b/packages/steppers/src/Stepper.stories.ts
@@ -212,6 +212,80 @@ Linear.parameters = {
   },
 };
 
+export const Clickable = (args:Args) => ({
+  components: {
+    VStepper,
+  },
+  setup() {
+    const val = ref(args?.modelValue || 0);
+
+    const clickable = [true, false, true, true];
+    const disableRouteActive = [false, false, true, false];
+    const linkable = [false, false, false, true];
+
+    const nuArgs = {
+      args: clickable.map((e, idx) => {
+        return {
+          ...args,
+          modelValue: val,
+          disableRouteActive: disableRouteActive[idx],
+          clickable: clickable[idx],
+          linkable: linkable[idx],
+        }
+      }),
+      clickable
+    }
+
+    const onPrevClick = () => {
+        val.value -= 1;
+    }
+    const onNextClick = () => {
+      val.value += 1;
+    }
+
+    const onStepClick = (step:any) => {
+      alert('You clicked a step! ' + JSON.stringify(step));
+
+      val.value = step.index;
+    }
+
+    return {args:nuArgs, clickable, val, onPrevClick, onNextClick, onStepClick};
+  },
+  template: `
+    <div class="flex flex-col gap-4">
+      <div v-for="(val, idx) in clickable">
+        <p class="mb-2">
+          {{idx === 0 ? 'Clickable w/ Disable Route Active' : '' }}
+          {{idx === 1 ? 'Disable Route Active' : ''}}
+          {{idx === 2 ? 'Clickable w/ Route Active and not Linkable' : ''}}
+          {{idx === 3 ? 'Clickable w/ Route Active and Linkable' : ''}}
+        </p>
+        <v-stepper v-bind="args.args[idx]" @click="onStepClick"/>
+      </div>
+
+      <div class="flex gap-4 my-4 items-center justify-center">
+        <button class="border-[1px] border-gray-400 p-2" @click="onPrevClick">
+          Prev
+        </button>
+        <button class="border-[1px] border-gray-400 p-2" @click="onNextClick">
+          Next
+        </button>
+      </div>
+    </div>
+  `,
+});
+Clickable.parameters = {
+  docs: {
+    source: {
+      code: `
+<v-steppers clickable disable-route-active />
+<v-steppers :clickable="false" />
+<v-steppers clickable />
+      `,
+    },
+  },
+};
+
 
 export const DisableRouteActive = Template.bind({});
 DisableRouteActive.args = {

--- a/packages/steppers/src/Stepper.vue
+++ b/packages/steppers/src/Stepper.vue
@@ -9,6 +9,7 @@ type Props = {
   modelValue: number;
   disableRouteActive?: boolean;
   linkable?: boolean;
+  clickable?: boolean;
   vertical?: boolean;
   linear?:boolean
 };
@@ -18,15 +19,26 @@ const props = withDefaults(defineProps<Props>(), {
   items: () => [],
   disableRouteActive: false,
   linkable: false,
+  clickable: false,
   vertical: false,
   linear: false,
 });
 
-const emit = defineEmits(['update:modelValue']);
+const emit = defineEmits(['update:modelValue', 'click']);
 
-const {items, modelValue, linkable, disableRouteActive} = toRefs(props);
+const {items, modelValue, linkable, disableRouteActive, clickable} = toRefs(props);
 
-const tag = computed(() => (linkable.value ? 'router-link' : 'div'));
+const tag = computed(() => {
+  if(linkable.value) {
+    return 'router-link';
+  }
+
+  if(clickable.value){
+   return 'button';
+  }
+
+  return 'div';
+});
 
 const activeIndex = ref(modelValue.value);
 
@@ -72,6 +84,7 @@ if (!disableRouteActive.value) {
         :active-index="activeIndex"
         :active="linear ? activeIndex >= idx : activeIndex === idx"
         :as="tag"
+        @click="clickable ? emit('click', {item, index:idx}) : null"
         :vertical="vertical"
         :linear="linear"
         :last="idx === (items.length -1)"


### PR DESCRIPTION
Add `clickable` prop to optionally allows `click` event to be emitted when user clicked on the step items.

Added new story to demonstrate how this prop works and updated the vuepress docs for this prop.