### PR TITLE
feat(VCheckbox): refactor to be uncontrolled by default

### DIFF
--- a/packages/forms/src/checkbox/VCheckbox.stories.ts
+++ b/packages/forms/src/checkbox/VCheckbox.stories.ts
@@ -224,3 +224,82 @@ export const ValidationMode: Story<{}> = () => ({
     </form>
   `,
 });
+
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VCheckbox},
+  setup() {
+    const modelValue = ref('');
+    const modelValue2 = ref('');
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm({}) : {
+      handleSubmit: (cb: any) => null,
+      resetForm: () => null,
+      values: {},
+    };
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert('onChange');
+    };
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, onChange};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <h1 class="mb-8 font-semibold">{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="mb-4">
+      <v-checkbox
+        wrapper-class="mb-4"
+        :name="'agreement'"
+        label="Only Name"
+      />
+      <div class="text-xs">
+        When used without vee validate, should not change "Vmodel" value or any other value unless
+        explicitly implemented. With vee validate, should update form values under "agreement"
+      </div>
+    </div>
+
+    <div class="mb-4">
+      <v-checkbox
+        wrapper-class="mb-4"
+        v-model="modelValue"
+        label="Only VModel"
+      />
+      <div class="text-xs">Should update form values under "modelValue" only</div>
+    </div>
+
+    <div class="mb-4">
+      <v-checkbox
+        v-model="modelValue2"
+        name="agreement2"
+        label="VModel and Name"
+      />
+      <div class="text-xs">Should update form values under "agreement2" (with vee validate) key AND "modelValue2"</div>
+    </div>
+
+
+    <div class="mb-4">
+      <v-checkbox
+        label="Uncontrolled"
+        placeholder="Uncontrolled input"
+        @change="onChange"
+      />
+      <div class="text-xs">Should not change any value unless explicitly implemented</div>
+    </div>
+
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR change the underlying behavior of VCheckbox from relying on VeeValidate behavior and existence of modelValue prop being defined to behave similarly to uncontrolled inputs. This makes the component behavior more predictable and allow it to work without requiring specific stuff being setup in the environment that uses it.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
