### PR TITLE
feat(Textarea): refactor to be uncontrolled by default + add labelClass prop

### DIFF
--- a/docs/components/textarea.md
+++ b/docs/components/textarea.md
@@ -244,7 +244,7 @@ const onSubmit = handleSubmit((values) => {
 ## Props
 
 | Name                                | Type               | Default        |
-| ----------------------------------- | ------------------ | -------------- |
+|-------------------------------------| ------------------ | -------------- |
 | [`modelValue`](#modelValue)         | `string`           | `''`           |
 | [`rows`](#rows)                     | `string \| number` | `undefined`    |
 | [`value`](#value)                   | `string`           | `''`           |
@@ -260,6 +260,7 @@ const onSubmit = handleSubmit((values) => {
 | [`rules`](#rules)                   | `string`           | `''`           |
 | [`wrapperClass`](#wrapperClass)     | `string`           | `''`           |
 | [`inputClass`](#inputClass)         | `string`           | `''`           |
+| [`labelClass`](#labelClass)         | `string`           | `''`           |
 | [`validationMode`](#validationMode) | `string`           | `'aggressive'` |
 
 ## Events

--- a/packages/forms/src/textarea/Textarea.stories.ts
+++ b/packages/forms/src/textarea/Textarea.stories.ts
@@ -187,3 +187,83 @@ export const ValidationMode: Story<{}> = () => ({
     </form>
   `,
 });
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VTextarea},
+  setup() {
+    const modelValue = ref('');
+    const modelValue2 = ref('');
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm() : {
+      handleSubmit: (cb: any) => null,
+      resetForm: () => null,
+      values: {},
+    };
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert('onChange');
+    };
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, onChange};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <h1 class="mb-8 font-semibold">{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="flex flex-wrap gap-4">
+      <div class="flex-1">
+        <v-textarea
+          name="description"
+          label="Only Name"
+        />
+        <div class="text-xs">
+          When used without vee validate, should not change "Vmodel" value or any other value unless
+          explicitly implemented<br/>
+          With vee validate, it should update form values under "description" key
+        </div>
+      </div>
+
+      <div class="flex-1">
+        <v-textarea
+          v-model="modelValue"
+          label="Only VModel"
+        />
+        <div class="text-xs">Should update "modelValue" only</div>
+      </div>
+
+      <div class="flex-1">
+        <v-textarea
+          v-model="modelValue2"
+          name="description2"
+          label="VModel and Name"
+        />
+        <div class="text-xs">
+          Should update form values under "description2" (w/ vee validate) key AND "modelValue2"
+        </div>
+      </div>
+      
+      <div class="flex-1">
+        <v-textarea
+          label="Uncontrolled"
+          @change="onChange"
+        />
+        <div class="text-xs">Should not change any value unless explicitly implemented</div>
+      </div>
+      
+    </div>
+
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};

--- a/packages/forms/src/textarea/Textarea.vue
+++ b/packages/forms/src/textarea/Textarea.vue
@@ -70,6 +70,10 @@ const props = defineProps({
     type: String,
     default: '',
   },
+  labelClass: {
+    type: String,
+    default: '',
+  },
   validationMode: {
     type: String as PropType<'aggressive' | 'eager'>,
     default: 'aggressive',
@@ -126,7 +130,7 @@ const validationListeners = computed(() => {
       wrapperClass,
     ]"
   >
-    <label v-if="label" :for="name" class="v-input-label">{{ label }}</label>
+    <label v-if="label" :for="name" class="v-input-label" :class="labelClass">{{ label }}</label>
     <textarea
       :id="name"
       v-model="value"


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR added `labelClass` prop to provide similar usages as other fields.

This PR also change the underlying behavior of `Textarea` from relying on `VeeValidate` behavior and existence of `modelValue` prop being defined to behave similarly to uncontrolled inputs. This makes the component behavior more predictable and allow it to work without requiring specific stuff being setup in the environment that uses it.

I've also added a story called `TestInputState` to easily test the component behavior introduced in this PR in storybook.

The story tested the component with common usage below:

- with `v-model` only,
- by passing `name` prop only,
- by using both `v-model` and `name` prop,
- and by using neither.

under two conditions: with and without VeeValidate `useForm` being defined in parent component.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
