### PR TITLE
feat(radio): refactor to be uncontrolled by default

### DIFF
--- a/packages/forms/src/radio/VRadio.stories.ts
+++ b/packages/forms/src/radio/VRadio.stories.ts
@@ -5,6 +5,7 @@ import {Meta, Story} from '@storybook/vue3';
 import {useForm} from 'vee-validate';
 import {object, string} from 'yup';
 import VBtn from '@gits-id/button';
+import {ref} from 'vue';
 
 export default {
   title: 'Forms/Radio',
@@ -105,3 +106,92 @@ export const Validation: Story<{}> = () => ({
     </form>
 `,
 });
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VRadio},
+  setup() {
+    const modelValue = ref();
+    const modelValue2 = ref();
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm({
+      initialValues: {
+        radio: false,
+        radio2: false
+      }
+    }) : {
+      handleSubmit: (cb: any) => null,
+      resetForm: () => null,
+      values: {},
+    };
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert('onChange');
+    };
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, onChange};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <h1 class="mb-8 font-semibold">{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="flex flex-wrap gap-4">
+      <div class="flex-1">
+        <v-radio
+          name="radio"
+          label="Only Name"
+          value="name"
+        />
+        <div class="text-xs">
+          When used without vee validate, should not change "Vmodel" value or any other value unless
+          explicitly implemented<br/>
+          With vee validate, it should update form values under "radio" key
+        </div>
+      </div>
+
+      <div class="flex-1">
+        <v-radio
+          v-model="modelValue"
+          label="Only VModel"
+          value="vmodel"
+        />
+        <div class="text-xs">Should update "modelValue" only</div>
+      </div>
+
+      <div class="flex-1">
+        <v-radio
+          v-model="modelValue2"
+          name="radio2"
+          label="VModel and Name"
+          value="vmodelname"
+        />
+        <div class="text-xs">
+          Should update form values under "radio2" (w/ vee validate) key AND "modelValue2"
+        </div>
+      </div>
+      
+      <div class="flex-1">
+        <v-radio
+          label="Uncontrolled"
+          @change="onChange"
+          value="uncontrolled"
+        />
+        <div class="text-xs">Should not change any value unless explicitly implemented</div>
+      </div>
+      
+    </div>
+
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};

--- a/packages/forms/src/radio/VRadio.vue
+++ b/packages/forms/src/radio/VRadio.vue
@@ -6,7 +6,7 @@ export default {
 
 <script setup lang="ts">
 import {useField} from 'vee-validate';
-import {toRefs, watch} from 'vue';
+import {ref, toRefs, watch} from 'vue';
 
 const props = defineProps({
   modelValue: {
@@ -75,18 +75,23 @@ const props = defineProps({
 });
 
 const {modelValue, rules, label, inputClass, name, id} = toRefs(props);
+const uncontrolledValue = ref();
 
 const emit = defineEmits(['update:modelValue']);
 
 type RadioValue = string | number | string[] | undefined;
 
-const {value: inputValue, errorMessage} = useField<RadioValue>(name, rules, {
+const {value: vvValue, errorMessage, setValue} = useField<RadioValue>(name, rules, {
   initialValue: modelValue.value,
 });
 
 watch(
-  inputValue,
+  uncontrolledValue,
   (val) => {
+    if (name.value) {
+      setValue(val);
+    }
+
     emit('update:modelValue', val);
   },
   {immediate: true},
@@ -95,7 +100,15 @@ watch(
 watch(
   modelValue,
   (val) => {
-    inputValue.value = val;
+    uncontrolledValue.value = val;
+  },
+  {immediate: true},
+);
+
+watch(
+  vvValue,
+  (val) => {
+    uncontrolledValue.value = val;
   },
   {immediate: true},
 );
@@ -114,7 +127,7 @@ watch(
     <div class="v-radio-group" :class="groupClass">
       <input
         :id="id"
-        v-model="inputValue"
+        v-model="uncontrolledValue"
         type="radio"
         :name="name"
         :value="value"

--- a/packages/forms/src/radio/VRadioGroup.stories.ts
+++ b/packages/forms/src/radio/VRadioGroup.stories.ts
@@ -211,3 +211,99 @@ export const ValidationMode: Story<{}> = () => ({
     </form>
   `,
 });
+
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VRadioGroup},
+  setup() {
+    const items = ['fire', 'earth', 'wind', 'water'];
+
+    const modelValue = ref();
+    const modelValue2 = ref();
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm({
+      initialValues: {
+        radio: '',
+        radio2: ''
+      }
+    }) : {
+      handleSubmit: (cb: any) => null,
+      resetForm: () => null,
+      values: {},
+    };
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert('onChange');
+    };
+
+    return {args, onSubmit, resetForm, values, items, modelValue, modelValue2, onChange};
+  },
+  template: `
+    <form @submit="onSubmit" class="border-none">
+    <h1 class="mb-8 font-semibold">{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="flex flex-wrap gap-4">
+      <div class="flex-1">
+        <v-radio-group
+          name="radio"
+          label="Only Name"
+          value="name"
+          :items="items"
+        />
+        <div class="text-xs">
+          When used without vee validate, should not change "Vmodel" value or any other value unless
+          explicitly implemented<br/>
+          With vee validate, it should update form values under "radio" key
+        </div>
+      </div>
+
+      <div class="flex-1">
+        <v-radio-group
+          v-model="modelValue"
+          label="Only VModel"
+          value="vmodel"
+          :items="items"
+        />
+        <div class="text-xs">Should update "modelValue" only</div>
+      </div>
+
+      <div class="flex-1">
+        <v-radio-group
+          v-model="modelValue2"
+          name="radio2"
+          label="VModel and Name"
+          value="vmodelname"
+          :items="items"
+        />
+        <div class="text-xs">
+          Should update form values under "radio2" (w/ vee validate) key AND "modelValue2"
+        </div>
+      </div>
+      
+      <div class="flex-1">
+        <v-radio-group
+          label="Uncontrolled"
+          @change="onChange"
+          value="uncontrolled"
+          :items="items"
+        />
+        <div class="text-xs">Should not change any value unless explicitly implemented</div>
+      </div>
+      
+    </div>
+
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};

--- a/packages/forms/src/radio/VRadioGroup.vue
+++ b/packages/forms/src/radio/VRadioGroup.vue
@@ -118,6 +118,7 @@ const emit = defineEmits([
   'blur',
 ]);
 
+const uncontrolledValue = ref();
 const groupRef = ref();
 
 const isEagerValidation = computed(() => {
@@ -125,10 +126,11 @@ const isEagerValidation = computed(() => {
 });
 
 const {
-  value: selected,
+  value: vvValue,
   errorMessage,
   validate,
   meta,
+  setValue
 } = useField(name, rules, {
   initialValue: modelValue.value || value.value,
   validateOnValueUpdate: !isEagerValidation.value,
@@ -148,7 +150,19 @@ const getText = (item: RadioItem) => {
   return typeof item === 'object' ? item?.[itemText.value] : item;
 };
 
-watch(selected, (val) => {
+watch(modelValue, (val) => {
+  uncontrolledValue.value = val;
+})
+
+watch(vvValue, (val) => {
+  uncontrolledValue.value = val;
+})
+
+watch(uncontrolledValue, (val) => {
+  if(name?.value){
+    setValue(val)
+  }
+
   emit('update:modelValue', val);
   emit('update:value', val);
   emit('input', val);
@@ -156,18 +170,6 @@ watch(selected, (val) => {
 });
 
 const {class: sizeClass} = useTextSize(size.value);
-
-const setInnerValue = (val: Value) => {
-  selected.value = val;
-};
-
-watch(modelValue, (val) => {
-  setInnerValue(val);
-});
-
-watch(value, (val) => {
-  setInnerValue(val);
-});
 
 const onChange = (event: any) => {
   emit('change', event);
@@ -232,7 +234,7 @@ onBeforeUnmount(() => {
       <label v-for="(item, index) in items" :key="index">
         <input
           :id="id || name"
-          v-model="selected"
+          v-model="uncontrolledValue"
           @blur="handleBlur"
           :name="name"
           type="radio"
@@ -248,7 +250,7 @@ onBeforeUnmount(() => {
           :disabled="disabled"
           @change="onChange"
         />
-        <slot name="label" :item="item" :selected="selected">
+        <slot name="label" :item="item" :selected="uncontrolledValue">
           <span :class="[sizeClass, error ? 'text-error' : 'text-gray-700']">
             {{ getText(item) }}
           </span>


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR change the underlying behavior of `VRadio` and `VRadioGroup` from relying on `VeeValidate` behavior and existence of `modelValue` prop being defined to behave similarly to uncontrolled inputs. This makes the component behavior more predictable and allow it to work without requiring specific stuff being setup in the environment that uses it.

I've also added a story called `TestInputState` to easily test the component behavior introduced in this PR in storybook.

The story tested the component with common usage below:

- with `v-model` only,
- by passing `name` prop only,
- by using both `v-model` and `name` prop,
- and by using neither.

under two conditians: with and without VeeValidate `useForm` being defined in parent component.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
