### PR TITLE
feat(VInput): refactor to be uncontrolled by default

### DIFF
--- a/docs/components/input.md
+++ b/docs/components/input.md
@@ -669,34 +669,6 @@ const handle = () => alert('Triggered!');
 </template>
 ```
 
-- [`blur`](#blur)
-
-Triggered when the input element loses focus.
-
-```vue
-<script setup lang="ts">
-const handle = () => alert('Triggered!');
-</script>
-
-<template>
-  <VInput @blur="handle" />
-</template>
-```
-
-- [`change`](#change)
-
-Triggered when the value of the input element changes and the element loses focus.
-
-```vue
-<script setup lang="ts">
-const handle = () => alert('Triggered!');
-</script>
-
-<template>
-  <VInput @change="handle" />
-</template>
-```
-
 - [`clickPrepend`](#clickPrepend)
 
 Triggered when the element with the `prepend` slot is clicked.

--- a/packages/forms/src/input/VInput.stories.ts
+++ b/packages/forms/src/input/VInput.stories.ts
@@ -563,3 +563,82 @@ export const FormsPlayground: Story<VInputProps> = () => ({
   components: {FormsPlaygroundComponent},
   template: `<FormsPlaygroundComponent />`,
 });
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VInput},
+  setup() {
+    const modelValue = ref('');
+    const modelValue2 = ref('');
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm({
+      initialValues: {
+        text: '',
+        text2: '',
+      }
+    }) : {handleSubmit: (cb: any) => null, resetForm: () => null, values: {}};
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert("onChange: " + val);
+    };
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, onChange};
+  },
+  template: `
+    <form @submit='onSubmit' class='border-none'>
+    <h1 class='mb-8 font-semibold'>{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="flex flex-wrap">
+      <div class='w-1/2 p-2'>
+        <v-input
+          name='text'
+          label='Only Name'
+        />
+        <div class='text-xs'>
+          When used without vee validate, should not change "Vmodel" value or any other value unless
+          explicitly implemented<br/>
+          With veevalidate, should update form values under "text" key only
+        </div>
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-input
+          v-model='modelValue'
+          label='Only VModel'
+        />
+        <div class='text-xs'>Should update "modelValue" only</div>
+      </div>
+
+      <div class='w-1/2 p-2'>
+        <v-input
+          v-model='modelValue2'
+          name='text2'
+          label='VModel and Name'
+        />
+        <div class='text-xs'>Should update form values under "text2" (with vee validate) key AND "modelValue2"</div>
+      </div>
+      
+      <div class='w-1/2 p-2'>
+        <v-input
+          label='Uncontrolled'
+          placeholder='Uncontrolled input'
+          @change="onChange"
+        />
+        <div class='text-xs'>Should not change any value unless explicitly implemented</div>
+      </div>
+    </div>
+
+    <div class='mt-4'>
+      <v-btn type='submit'>Submit</v-btn>
+      <v-btn type='button' text @click='resetForm'>Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -159,6 +159,7 @@ const props = defineProps({
 });
 
 const {
+  modelValue,
   type,
   readonly,
   disabled,
@@ -171,8 +172,6 @@ const {
 
 const emit = defineEmits([
   'update:modelValue',
-  'blur',
-  'change',
   'clickPrepend',
   'clickPrependIcon',
   'clickAppend',
@@ -185,18 +184,34 @@ const isEagerValidation = computed(() => {
 });
 
 const input = ref();
+const uncontrolledValue = ref();
 
 const {
-  value: inputValue,
+  value: vvValue,
   errorMessage,
   handleChange,
   resetField,
+  setValue,
 } = useField(name, rules, {
   initialValue: props.modelValue || props.value,
   validateOnValueUpdate: !isEagerValidation.value,
 });
 
-watch(inputValue, (val) => emit('update:modelValue', val));
+watch(modelValue, (val) => {
+  uncontrolledValue.value = val;
+});
+
+watch(vvValue, (val) => {
+  uncontrolledValue.value = val;
+});
+
+watch(uncontrolledValue, (val) => {
+  if (name.value) {
+    setValue(val);
+  }
+
+  emit('update:modelValue', val);
+});
 
 const validationListeners = computed(() => {
   // If the field is valid or have not been validated yet
@@ -241,7 +256,7 @@ const clear = () => {
         {{ label }}
       </label>
     </slot>
-    <div v-if="text" v-bind="$attrs" class="v-input-text">{{ inputValue }}</div>
+    <div v-if="text" v-bind="$attrs" class="v-input-text">{{ uncontrolledValue }}</div>
     <div v-else class="v-input-wrapper">
       <slot name="prepend.outer">
         <div
@@ -263,7 +278,7 @@ const clear = () => {
       </slot>
       <input
         :id="id || name"
-        v-model="inputValue"
+        v-model="uncontrolledValue"
         v-on="validationListeners"
         ref="input"
         class="v-input-control"
@@ -298,7 +313,7 @@ const clear = () => {
           </slot>
         </div>
       </slot>
-      <slot v-if="clearable && inputValue" name="clearable">
+      <slot v-if="clearable && uncontrolledValue" name="clearable">
         <button
           type="button"
           aria-label="Clear"
@@ -316,7 +331,7 @@ const clear = () => {
       </slot>
     </div>
 
-    <div v-if="errorMessage" class="v-input-error" :class='errorClass'>
+    <div v-if="errorMessage" class="v-input-error" :class="errorClass">
       {{ errorMessage }}
     </div>
   </div>


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR change the underlying behavior of `VInput` from relying on `VeeValidate` behavior and existence of `modelValue` prop being defined to behave similarly to uncontrolled inputs. This makes the component behavior more predictable and allow it to work without requiring specific stuff being setup in the environment that uses it.

This PR also remove unimplemented event of `blur` and `change` from `emit` declaration, allowing the fallthrough attribute to work as it should be for those events. Documentation has been updated to reflect this change too.

I've also added a story called `TestInputState` to easily test the component behavior introduced in this PR in storybook.

The story tested the component with common usage below:

- with `v-model` only,
- by passing `name` prop only,
- by using both `v-model` and `name` prop,
- and by using neither.

under two conditions: with and without VeeValidate `useForm` being defined in parent component.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
