### PR TITLE
feat(VFormSelect): refactor to be uncontrolled by default

### DIFF
--- a/packages/forms/src/form-select/VFormSelect.stories.ts
+++ b/packages/forms/src/form-select/VFormSelect.stories.ts
@@ -319,3 +319,105 @@ export const IntialValues: Story<{}> = (args) => ({
     </form>
 `,
 });
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VFormSelect},
+  setup() {
+    const modelValue = ref();
+    const modelValue2 = ref();
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm({
+      initialValues: {
+        choice: '',
+        choice2: '',
+      }
+    }) : {handleSubmit: (cb: any) => null, resetForm: () => null, values: {}};
+
+    const items = ref([
+      {
+        text: 'Water',
+        value: 'water',
+      },
+      {
+        text: 'Earth',
+        value: 'earth',
+      },
+      {
+        text: 'Fire',
+        value: 'fire',
+      },
+      {
+        text: 'Wind',
+        value: 'wind',
+      },
+    ]);
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert("onChange: " + val);
+    };
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, items, onChange};
+  },
+  template: `
+    <form @submit='onSubmit' class='border-none'>
+    <h1 class='mb-8 font-semibold'>{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="flex flex-wrap">
+      <div class='w-1/2 p-2'>
+        <v-form-select
+          name='choice'
+          label='Only Name'
+          :items="items"
+        />
+        <div class='text-xs'>
+          When used without vee validate, should not change "Vmodel" value or any other value unless
+          explicitly implemented<br/>
+          With veevalidate, should update form values under "choice" key only
+        </div>
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-form-select
+          v-model='modelValue'
+          label='Only VModel'
+          :items="items"
+        />
+        <div class='text-xs'>Should update "modelValue" only</div>
+      </div>
+
+      <div class='w-1/2 p-2'>
+        <v-form-select
+          v-model='modelValue2'
+          name='choice2'
+          label='VModel and Name'
+          :items="items"
+        />
+        <div class='text-xs'>Should update form values under "choice2" (with vee validate) key AND "modelValue2"</div>
+      </div>
+      
+      <div class='w-1/2 p-2'>
+        <v-form-select
+          label='Uncontrolled'
+          placeholder='Uncontrolled input'
+          @change="onChange"
+          :items="items"
+        />
+        <div class='text-xs'>Should not change any value unless explicitly implemented</div>
+      </div>
+    </div>
+
+    <div class='mt-4'>
+      <v-btn type='submit'>Submit</v-btn>
+      <v-btn type='button' text @click='resetForm'>Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};

--- a/packages/forms/src/form-select/VFormSelect.vue
+++ b/packages/forms/src/form-select/VFormSelect.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import {toRefs, PropType, watch, computed} from 'vue';
+import {toRefs, PropType, watch, computed, ref} from 'vue';
 import {useField} from 'vee-validate';
 import type {VFormSelectItem} from './types';
 
@@ -89,6 +89,7 @@ const {
   rules,
   validationMode,
 } = toRefs(props);
+const uncontrolledValue = ref();
 
 const isEagerValidation = computed(() => {
   return validationMode.value === 'eager';
@@ -99,15 +100,20 @@ const message = computed(() => {
 });
 
 const {
-  value: inputValue,
+  value: vvValue,
   errorMessage,
   validate,
+  setValue,
 } = useField(name, rules, {
   initialValue: value.value || modelValue.value,
   validateOnValueUpdate: !isEagerValidation.value,
 });
 
-watch(inputValue, (val) => {
+watch(uncontrolledValue, (val) => {
+  if (name?.value) {
+    setValue(val);
+  }
+
   emit('update:modelValue', val);
 
   if (errorMessage.value && isEagerValidation.value) {
@@ -116,7 +122,11 @@ watch(inputValue, (val) => {
 });
 
 watch(modelValue, (val) => {
-  inputValue.value = val;
+  uncontrolledValue.value = val;
+});
+
+watch(vvValue, (val) => {
+  uncontrolledValue.value = val;
 });
 
 const getValue = (option: string | Record<string, any>) => {
@@ -149,7 +159,7 @@ const handleBlur = () => {
       {{ label }}
     </label>
     <select
-      v-model="inputValue"
+      v-model="uncontrolledValue"
       @blur="handleBlur"
       class="v-input-control"
       :disabled="disabled"


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR change the underlying behavior of `VFormSelect` from relying on VeeValidate behavior and existence of `modelValue` prop being defined to behave similarly to uncontrolled inputs. This makes the component behavior more predictable and allow it to work without requiring specific stuff being setup in the environment that uses it.

I've also added a story called `TestInputState` to easily test the component behavior introduced in this PR in storybook.

The story tested the component with common usage below:

- with `v-model` only,
- by passing `name` prop only,
- by using both `v-model` and `name` prop,
- and by using neither.

under two conditions: with and without VeeValidate `useForm` being defined in parent component.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
