### PR TITLE
feat(VRadioGroup): add selectedClass and defaultClass to style radio

### DIFF
--- a/docs/components/radio-group.md
+++ b/docs/components/radio-group.md
@@ -136,6 +136,39 @@ const items = ref([
 
 </LivePreview>
 
+### Disabled
+
+To disable the `VRadioGroup` component and prevent user interaction, set the `disabled` prop to `true`.
+
+<LivePreview src="forms-radiogroup--disabled" >
+
+```vue
+<script setup lang="ts">
+import {ref} from 'vue';
+
+const items = ref([
+  {
+    text: 'Item 1',
+    value: 1,
+  },
+  {
+    text: 'Item 2',
+    value: 2,
+  },
+  {
+    text: 'Item 3',
+    value: 3,
+  },
+]);
+</script>
+
+<template>
+  <VRadioGroup label="Select" :items="items" disabled />
+</template>
+```
+
+</LivePreview>
+
 ### Validation
 
 The `VRadioGroup` component can be used in a form with form validation by using a form handling library such as `VeeValidate`.
@@ -276,10 +309,48 @@ const onSubmit = handleSubmit((values) => {
 
 :::
 
+### Styling selected item
+
+To style selected item distinctively, pass your class to `selectedClass` prop, or `defaultClass` to set a default classes
+for the items.
+
+<LivePreview src="forms-radiogroup--customization" />
+
+```vue
+<script setup lang="ts">
+import {ref} from 'vue';
+
+const items = ref([
+  {
+    text: 'Item 1',
+    value: 1,
+  },
+  {
+    text: 'Item 2',
+    value: 2,
+  },
+  {
+    text: 'Item 3',
+    value: 3,
+  },
+]);
+</script>
+
+<template>
+  <VRadioGroup
+    :items="items"
+    label="Pick an option"
+    labelClass="!text-purple-500" ,
+    defaultClass="p-2 my-1 hover=bg-primary-50 border-grey-300 border rounded-lg cursor-pointer" ,
+    selectedClass="!border-primary-300 !text-primary-500"
+  />
+</template>
+```
+
 ## Props
 
 | Name                                | Type                                                   | Default                         |
-| ----------------------------------- | ------------------------------------------------------ | ------------------------------- |
+|-------------------------------------|--------------------------------------------------------|---------------------------------|
 | [`modelValue`](#modelValue)         | `[String, Number, Object, Boolean] as PropType<Value>` | `null`                          |
 | [`value`](#value)                   | `[String, Number, Object, Boolean] as PropType<Value>` | `null`                          |
 | [`label`](#label)                   | `String`                                               | `''`                            |
@@ -295,10 +366,12 @@ const onSubmit = handleSubmit((values) => {
 | [`inline`](#inline)                 | `Boolean`                                              | `false`                         |
 | [`hideError`](#hideError)           | `Boolean`                                              | `false`                         |
 | [`labelClass`](#labelClass)         | `String`                                               | `''`                            |
-| [`errorClass`](#errorClass)         | `String`                                               | `'text-error-600 text-sm mt-1'` |
+| [`errorClass`](#errorClass)         | `String`                                               | `''`                            |
+| [`defaultClass`](#errorClass)       | `String`                                               | `''`                            |
+| [`selectedClass`](#errorClass)      | `String`                                               | `'text-error-600 text-sm mt-1'` |
 | [`rules`](#rules)                   | `String`                                               | `''`                            |
 | [`id`](#id)                         | `String`                                               | `''`                            |
-| [`validationMode`](#validationMode) | `String as PropType<'aggressive' \| 'eager'>`          | `'aggressive'`                  |
+| [`validationMode`](#validationMode) | `'aggressive'` &#x7c; `'eager'`                        | `'aggressive'`                  |
 
 ## Events
 
@@ -364,7 +437,18 @@ export default {
 
 ## Slots
 
-None
+### `label`
+
+Customize radio label text
+
+```vue
+<VRadioGroup>
+  <template #label="{item, selected}">
+    <span>{{ item.title }}</span>
+  </template>
+</VRadioGroup>
+```
+
 
 ## CSS Variables
 

--- a/packages/forms/src/radio/VRadioGroup.stories.ts
+++ b/packages/forms/src/radio/VRadioGroup.stories.ts
@@ -96,6 +96,21 @@ NoLabel.parameters = {
   },
 };
 
+export const Customization = Template.bind({});
+Customization.args = {
+  label: 'Pick an option',
+  labelClass: '!text-purple-500',
+  defaultClass: 'p-2 my-1 hover:bg-primary-50 border-grey-300 border rounded-lg cursor-pointer',
+  selectedClass: '!border-primary-300 !text-primary-500'
+};
+Customization.parameters = {
+  docs: {
+    source: {
+      code: '<v-radio-group default-class="" selected-class="" :items="items" label="" />',
+    },
+  },
+};
+
 export const Validation: Story<{}> = () => ({
   components: {VRadioGroup, VBtn},
   setup() {

--- a/packages/forms/src/radio/VRadioGroup.vue
+++ b/packages/forms/src/radio/VRadioGroup.vue
@@ -72,6 +72,14 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  defaultClass: {
+    type: String,
+    default: '',
+  },
+  selectedClass: {
+    type: String,
+    default: '',
+  },
   labelClass: {
     type: String,
     default: '',
@@ -231,7 +239,11 @@ onBeforeUnmount(() => {
       class="flex gap-y-2 sm:gap-y-0 gap-x-8"
       :class="[inline ? 'flex-row' : 'flex-col']"
     >
-      <label v-for="(item, index) in items" :key="index">
+      <label
+        :class="[uncontrolledValue === getValue(item) ? selectedClass :'', defaultClass]"
+        v-for="(item, index) in items"
+        :key="index"
+      >
         <input
           :id="id || name"
           v-model="uncontrolledValue"
@@ -251,7 +263,7 @@ onBeforeUnmount(() => {
           @change="onChange"
         />
         <slot name="label" :item="item" :selected="uncontrolledValue">
-          <span :class="[sizeClass, error ? 'text-error' : 'text-gray-700']">
+          <span :class="[sizeClass]">
             {{ getText(item) }}
           </span>
         </slot>


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR allows customization for radio group items depending on its state (selected or not) through `selectedClass` and `defaultClass` prop. Documentation has been updated and story has been added (title "Customization" to showcase the new props.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
