### PR TITLE
feat(VMultiSelect): refactor to be uncontrolled by default

### DIFF
--- a/packages/multi-select/src/VMultiSelect.stories.ts
+++ b/packages/multi-select/src/VMultiSelect.stories.ts
@@ -4,6 +4,7 @@ import {useForm} from 'vee-validate';
 import {object, array} from 'yup';
 import {computed, ref, onMounted} from 'vue';
 import {VMultiSelectItem} from './types';
+import {Story} from '@storybook/vue3';
 
 const items = [...Array(200)].map((_, index) => ({
   value: index + 1,
@@ -748,3 +749,90 @@ export const CustomSearchFunction = () => ({
     </form>
 `,
 });
+
+export const TestInputState: Story<{}> = (args) => ({
+  components: {VBtn, VMultiSelect},
+  setup() {
+    const modelValue = ref([]);
+    const modelValue2 = ref([]);
+    const {handleSubmit, resetForm, values} = args.useForm ? useForm({
+      initialValues: {
+        text: [],
+        text2: [],
+      }
+    }) : {handleSubmit: (cb: any) => null, resetForm: () => null, values: {}};
+
+    const items = ref(['seal|🦭', 'otter|🦦', 'giraffe|🦒', 'shark|🦈', 'dodo|🦤'].map((e) => ({
+      text: e.split('|')[1],
+      value:e.split('|')[0],
+    })))
+
+    const onSubmit = handleSubmit((values: any) => {
+      alert(JSON.stringify(values));
+    });
+
+    const onChange = (val: any) => {
+      alert("onChange: " + val);
+    };
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, items, onChange};
+  },
+  template: `
+    <form @submit='onSubmit' class='border-none'>
+    <h1 class='mb-8 font-semibold'>{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <div class="flex flex-wrap">
+      <div class='w-1/2 p-2'>
+        <v-multi-select
+          name='text'
+          label='Only Name'
+          :items="items"
+        />
+        <div class='text-xs'>
+          When used without vee validate, should not change "Vmodel" value or any other value unless
+          explicitly implemented<br/>
+          With veevalidate, should update form values under "text" key only
+        </div>
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-multi-select
+          v-model='modelValue'
+          label='Only VModel'
+          :items="items"
+        />
+        <div class='text-xs'>Should update "modelValue" only</div>
+      </div>
+
+      <div class='w-1/2 p-2'>
+        <v-multi-select
+          v-model='modelValue2'
+          name='text2'
+          label='VModel and Name'
+          :items="items"
+        />
+        <div class='text-xs'>Should update form values under "text2" (with vee validate) key AND "modelValue2"</div>
+      </div>
+      
+      <div class='w-1/2 p-2'>
+        <v-multi-select
+          label='Uncontrolled'
+          @change="onChange"
+          :items="items"
+        />
+        <div class='text-xs'>Should not change any value unless explicitly implemented</div>
+      </div>
+    </div>
+
+    <div class='mt-4'>
+      <v-btn type='submit'>Submit</v-btn>
+      <v-btn type='button' text @click='resetForm'>Reset</v-btn>
+    </div>
+
+    <pre>{{ {values, modelValue, modelValue2} }}</pre>
+    </form>
+  `,
+});
+TestInputState.args = {
+  useForm: false,
+};


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR change the underlying behavior of `VMultiSelect` from relying on VeeValidate behavior and existence of `modelValue` prop being defined to behave similarly to uncontrolled inputs. This makes the component behavior more predictable and allow it to work without requiring specific stuff being setup in the environment that uses it.

I've also added a story called `TestInputState` to easily test the component behavior introduced in this PR in storybook.

The story tested the component with common usage below:

- with `v-model` only,
- by passing `name` prop only,
- by using both `v-model` and `name` prop,
- and by using neither.

under two conditions: with and without VeeValidate `useForm` being defined in parent component.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
