### PR TITLE
fix(VInput): fix clearable and initial value not working

### DIFF
--- a/packages/forms/src/input/VInput.stories.ts
+++ b/packages/forms/src/input/VInput.stories.ts
@@ -591,48 +591,56 @@ export const TestInputState: Story<{}> = (args) => ({
     <h1 class='mb-8 font-semibold'>{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
 
     <div class="flex flex-wrap">
-      <div class='w-1/2 p-2'>
+      <div class="w-1/2 p-2">
         <v-input
-          name='text'
-          label='Only Name'
+          name="text"
+          label="Only Name"
+          :value="args.value"
+          :clearable="args.clearable"
         />
-        <div class='text-xs'>
+        <div class="text-xs">
           When used without vee validate, should not change "Vmodel" value or any other value unless
-          explicitly implemented<br/>
+          explicitly implemented<br />
           With veevalidate, should update form values under "text" key only
         </div>
       </div>
 
       <div class="w-1/2 p-2">
         <v-input
-          v-model='modelValue'
-          label='Only VModel'
+          v-model="modelValue"
+          label="Only VModel"
+          :value="args.value"
+          :clearable="args.clearable"
         />
-        <div class='text-xs'>Should update "modelValue" only</div>
+        <div class="text-xs">Should update "modelValue" only</div>
       </div>
 
-      <div class='w-1/2 p-2'>
+      <div class="w-1/2 p-2">
         <v-input
-          v-model='modelValue2'
-          name='text2'
-          label='VModel and Name'
+          v-model="modelValue2"
+          name="text2"
+          label="VModel and Name"
+          :value="args.value"
+          :clearable="args.clearable"
         />
-        <div class='text-xs'>Should update form values under "text2" (with vee validate) key AND "modelValue2"</div>
+        <div class="text-xs">Should update form values under "text2" (with vee validate) key AND "modelValue2"</div>
       </div>
-      
-      <div class='w-1/2 p-2'>
+
+      <div class="w-1/2 p-2">
         <v-input
-          label='Uncontrolled'
-          placeholder='Uncontrolled input'
+          label="Uncontrolled"
+          placeholder="Uncontrolled input"
           @change="onChange"
+          :value="args.value"
+          :clearable="args.clearable"
         />
-        <div class='text-xs'>Should not change any value unless explicitly implemented</div>
+        <div class="text-xs">Should not change any value unless explicitly implemented</div>
       </div>
     </div>
 
-    <div class='mt-4'>
-      <v-btn type='submit'>Submit</v-btn>
-      <v-btn type='button' text @click='resetForm'>Reset</v-btn>
+    <div class="mt-4">
+      <v-btn type="submit">Submit</v-btn>
+      <v-btn type="button" text @click="resetForm">Reset</v-btn>
     </div>
 
     <pre>{{ {values, modelValue, modelValue2} }}</pre>
@@ -641,4 +649,7 @@ export const TestInputState: Story<{}> = (args) => ({
 });
 TestInputState.args = {
   useForm: false,
+  setupWithInitialValue: false,
+  value: undefined,
+  clearable: true,
 };

--- a/packages/forms/src/input/VInput.stories.ts
+++ b/packages/forms/src/input/VInput.stories.ts
@@ -569,11 +569,13 @@ export const TestInputState: Story<{}> = (args) => ({
   setup() {
     const modelValue = ref('');
     const modelValue2 = ref('');
+    const initialValues = ref({
+      text: args.setupWithInitialValue ? 'init' : '',
+      text2: args.setupWithInitialValue ? 'init2' : '',
+    });
+
     const {handleSubmit, resetForm, values} = args.useForm ? useForm({
-      initialValues: {
-        text: '',
-        text2: '',
-      }
+      initialValues,
     }) : {handleSubmit: (cb: any) => null, resetForm: () => null, values: {}};
 
     const onSubmit = handleSubmit((values: any) => {
@@ -584,11 +586,31 @@ export const TestInputState: Story<{}> = (args) => ({
       alert("onChange: " + val);
     };
 
-    return {args, onSubmit, resetForm, values, modelValue, modelValue2, onChange};
+    const resetVVForm = () => {
+      if(!args.useForm){
+        alert('Story is not set up with Vee Validate Form. set `useForm` control to true to try this action.')
+      }
+
+      initialValues.value = {
+        text: 'changes',
+        text2: 'change me too!'
+      };
+
+      resetForm();
+    }
+
+    return {args, onSubmit, resetForm, values, modelValue, modelValue2, onChange, resetVVForm};
   },
   template: `
-    <form @submit='onSubmit' class='border-none'>
-    <h1 class='mb-8 font-semibold'>{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+    <form @submit="onSubmit" class="border-none">
+    <h1 class="mb-8 font-semibold">{{ args.useForm ? 'with' : 'without' }} VeeValidate Form</h1>
+
+    <button 
+      type="button" @click="resetVVForm" 
+      class="bg-red-400 text-white text-sm p-2 rounded"
+    >
+      Change Initial Value & Reset Form! <span class="text-[10px]">(Vee Validate only)</span>
+    </button>
 
     <div class="flex flex-wrap">
       <div class="w-1/2 p-2">
@@ -635,6 +657,36 @@ export const TestInputState: Story<{}> = (args) => ({
           :clearable="args.clearable"
         />
         <div class="text-xs">Should not change any value unless explicitly implemented</div>
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-input
+          value="doremi"
+          label="Initial Value w/ value prop "
+        />
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-input
+          model-value="fasola"
+          label="Initial Value w/ modelValue prop "
+        />
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-input
+          value="initival"
+          name="init1"
+          label="Initial Value w/ value prop + name"
+        />
+      </div>
+
+      <div class="w-1/2 p-2">
+        <v-input
+          model-value="modelvalue"
+          name="init2"
+          label="Initial Value w/ modelValue prop + name"
+        />
       </div>
     </div>
 

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -184,7 +184,8 @@ const isEagerValidation = computed(() => {
 });
 
 const input = ref();
-const uncontrolledValue = ref();
+const initialValue = ref(props.modelValue || props.value);
+const uncontrolledValue = ref(initialValue.value);
 
 const {
   value: vvValue,
@@ -192,6 +193,7 @@ const {
   handleChange,
   resetField,
   setValue,
+  meta,
 } = useField(name, rules, {
   initialValue: props.modelValue || props.value,
   validateOnValueUpdate: !isEagerValidation.value,
@@ -202,7 +204,11 @@ watch(modelValue, (val) => {
 });
 
 watch(vvValue, (val) => {
-  uncontrolledValue.value = val;
+  // only use vee validate value if name is defined
+  // to prevent whole form value being passed as field value
+  if (name.value) {
+    uncontrolledValue.value = val;
+  }
 });
 
 watch(uncontrolledValue, (val) => {
@@ -212,6 +218,12 @@ watch(uncontrolledValue, (val) => {
 
   emit('update:modelValue', val);
 });
+
+watch(meta, (val,prev) => {
+  if (name.value && val.initialValue !== initialValue.value) {
+    initialValue.value = val.initialValue || '';
+  }
+}, {deep: true});
 
 const validationListeners = computed(() => {
   // If the field is valid or have not been validated yet
@@ -238,6 +250,12 @@ const clear = () => {
   emit('clear');
   input.value?.focus();
 };
+
+
+// if name is defined, we override uncontrolledValue with initialValue from veeValidate
+if(name.value) {
+  uncontrolledValue.value = meta.initialValue || "";
+}
 </script>
 
 <template>

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -233,7 +233,8 @@ const validationListeners = computed(() => {
 });
 
 const clear = () => {
-  resetField();
+  uncontrolledValue.value = "";
+
   emit('clear');
   input.value?.focus();
 };


### PR DESCRIPTION
### 🔗 Linked issue

#96 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fix should resolve issues with clearable and initial value not working. `clerarable` now should clear the input value.
And initial value now will be honored. **However, when using VeeValidate, only `VInput` defined with `name` will have its initial value be affected by VeeValidate. Non-named inputs should either use `model-value` or `value` prop to initialize initialValue.**

I've updated the `TestInputState` story in storybook to show how the input works under different conditions.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
