### PR TITLE
feat(VDataTable): support multisort

### DIFF
--- a/docs/components/data-table.md
+++ b/docs/components/data-table.md
@@ -498,7 +498,7 @@ const search = ref('');
 ## Props
 
 | Name                                          | Type                                    | Default                  |
-| --------------------------------------------- | --------------------------------------- | ------------------------ |
+|-----------------------------------------------| --------------------------------------- | ------------------------ |
 | [`modelValue`](#modelValue)                   | `Array`                                 | `[]`                     |
 | [`value`](#value)                             | `Array`                                 | `[]`                     |
 | [`headers`](#headers)                         | `Array as PropType<VDataTableHeader[]>` | `[]`                     |
@@ -522,6 +522,7 @@ const search = ref('');
 | [`totalItems`](#totalItems)                   | `Number`                                | `0`                      |
 | [`page`](#page)                               | `Number`                                | `1`                      |
 | [`mustSort`](#mustSort)                       | `Boolean`                               | `false`                  |
+| [`multiSort`](#multiSort)                     | `Boolean`                               | `false`                  |
 | [`noShadow`](#noShadow)                       | `Boolean`                               | `false`                  |
 | [`selectable`](#selectable)                   | `Boolean`                               | `false`                  |
 | [`headerClass`](#headerClass)                 | `String`                                | `''`                     |

--- a/packages/table/src/VDataTable.stories.ts
+++ b/packages/table/src/VDataTable.stories.ts
@@ -10,13 +10,21 @@ import './VDataTablePagination.dark.scss';
 
 const states = ['active', 'inactive'];
 
-const items = [...Array(30)].map((_, index) => ({
-  index,
-  name: `User-${index}`,
-  email: `user-${index}@example.com`,
-  age: index + 1 * 10,
-  state: states[Math.floor(Math.random() * states.length)],
-}));
+const items = [...Array(30)].map((_, index) => {
+  const fName = ['Cory', 'Peppa', 'Gallagher', 'Caleb', 'Thomas'].at(Math.floor(Math.random()*5));
+  const lName = ['Smith', 'Woods', 'Stein', 'Bauer', 'Gordon'].at(Math.floor(Math.random()*5));
+  return ({
+    index,
+    name: [fName, lName].join(' '),
+    email: `user-${index}@example.com`,
+    age: index + 1 * 10,
+    state: states[Math.floor(Math.random() * states.length)],
+    address: {
+      city: ['Jakarta', 'Melbourne', 'London', 'Washington', 'Stockholm', 'Seoul', 'Moscoe', 'Cape Town'].at(index % 8),
+      street: '241 Lorem Street',
+    },
+  });
+});
 
 const headers = [
   {
@@ -24,6 +32,7 @@ const headers = [
     text: 'ID',
     class: '',
     tdClass: '',
+    sortable: false,
   },
   {
     value: 'name',
@@ -34,6 +43,12 @@ const headers = [
   {
     value: 'email',
     text: 'Email',
+    class: '',
+    tdClass: '',
+  },
+  {
+    value: 'address.city',
+    text: 'City',
     class: '',
     tdClass: '',
   },

--- a/packages/table/src/VDataTable.vue
+++ b/packages/table/src/VDataTable.vue
@@ -174,13 +174,17 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  multiSort: {
+    type: Boolean,
+    default: false,
+  }
 });
 
 const emit =
   defineEmits<{
     (e: 'update:search', value: string): void;
-    (e: 'update:sortBy', value: string): void;
-    (e: 'update:sortDirection', value: SortDirection): void;
+    (e: 'update:sortBy', value: string|string[]): void;
+    (e: 'update:sortDirection', value: SortDirection|SortDirection[]): void;
     (e: 'update:page', value: number): void;
     (e: 'update:itemsPerPage', value: number): void;
     (e: 'update:totalItems', value: number): void;
@@ -190,7 +194,7 @@ const emit =
     (e: 'pagination:change', value: Record<string, any>): void;
     (e: 'update:modelValue', value: any): void;
     (e: 'update:value', value: any): void;
-    (e: 'sort', payload: {sortBy: string; direction: SortDirection}): void;
+    (e: 'sort', payload: {sortBy: string|string[]; direction: SortDirection|SortDirection[]}): void;
     (e: 'row:click', item: VDataTableItem): void;
   }>();
 
@@ -215,13 +219,16 @@ const {
   modelValue,
   sortBy: sortByProp,
   sortDirection: sortDirectionProp,
+  multiSort,
 } = toRefs(props);
 
 const page = ref(paginationPage.value);
 const perPage = ref(itemsPerPage.value);
 const offset = computed(() => (page.value - 1) * Number(perPage.value));
-const sortBy = ref(sortByProp.value);
-const sortDirection = ref<SortDirection>(sortDirectionProp.value);
+const sortBy = ref<string|string[]>(multiSort.value && !Array.isArray(sortByProp.value) ? [sortByProp.value] : sortByProp.value);
+const sortDirection = ref<SortDirection|SortDirection[]>(multiSort.value && !Array.isArray(sortDirectionProp.value) ? [sortDirectionProp.value] :  sortDirectionProp.value);
+
+const sortMap = ref<Map<string, SortDirection>>(new Map());
 
 const defaultSearchBy = computed(() => headers.value.map((item) => item.value));
 
@@ -231,18 +238,35 @@ const paginatedItems = computed(() => {
   if (serverSide.value) return clonedItems;
 
   // sorting
-  if (sortBy.value && !serverSide.value) {
+  const sortByKey = Array.from(sortMap.value.keys());
+  if (sortByKey.length && !serverSide.value) {
     clonedItems.sort((a, b) => {
-      const aValue = +a[sortBy.value];
-      const bValue = +b[sortBy.value];
-      if (!isNaN(aValue) && !isNaN(bValue))
-        return Number(aValue) - Number(bValue);
+      let sortVal = 0;
 
-      return String(aValue).localeCompare(String(bValue));
+      // loop each sort key
+      sortByKey?.forEach((key: string) => {
+        // get value from path ie. user.name.first
+        const valA = get(a, key);
+        const valB = get(b, key);
+
+        // only do sort if sort value is 0 (meaning, no sort has been done for previous key)
+        // if multiSort is supported, this will sort next key only if previous key result is a === b,
+        // allowing correct sort order result instead of giving last-key order result.
+        if(sortVal === 0) {
+          if (!isNaN(+valA) && !isNaN(+valB)) {
+            sortVal = (+valA) - (+valB);
+          } else {
+            sortVal = valA.localeCompare(valB);
+          }
+
+          if (sortMap.value.get(key) === 'desc') {
+            sortVal = sortVal !== 0 ? -sortVal : 0;
+          }
+        }
+      });
+
+      return sortVal;
     });
-    if (sortDirection.value === 'desc') {
-      clonedItems.reverse();
-    }
   }
   // filter
   if (search.value && !serverSide.value) {
@@ -272,7 +296,7 @@ const computedHeaders = computed(() =>
 );
 
 const getThClass = (header: VDataTableHeader) => {
-  const isActive = header.sorting && sortBy.value === header.value;
+  const isActive = sortMap.value.get(header.value);
   return [
     {
       [`v-table-th--${header.align}`]: !!header.align,
@@ -301,35 +325,38 @@ const handleSort = (header: VDataTableHeader) => {
   if (!header) return;
 
   let direction: SortDirection = '';
-  if (mustSort.value) {
-    if (sortDirection.value === 'asc') {
-      direction = 'desc';
-    } else {
-      direction = 'asc';
-    }
-  } else {
-    if (sortDirection.value === '') {
-      direction = 'asc';
-    } else if (sortDirection.value === 'asc') {
-      direction = 'desc';
-    } else if (sortDirection.value === 'desc') {
-      direction = '';
-    }
+  let initDir = sortMap?.value?.get(header.value);
+
+  if (!initDir) {
+    direction = 'asc';
+  } else if (initDir === 'asc') {
+    direction = 'desc';
+  } else if (initDir === 'desc') {
+    direction = mustSort.value ? 'asc' : '';
   }
 
-  header.sorting = direction;
+  if(direction) {
+    if(multiSort.value) {
+      sortMap.value?.set(header.value, direction);
+    } else {
+      sortMap.value?.clear();
+      sortMap.value?.set(header.value, direction);
+    }
+  } else {
+    sortMap.value?.delete(header.value);
+  }
 
-  sortBy.value = header.value;
-  sortDirection.value = direction;
+  sortBy.value = multiSort.value ? Array.from(sortMap.value.keys()) : header.value;
+  sortDirection.value = multiSort.value ? Array.from(sortMap.value.values()) : direction;
 };
 
 // watch sorting
-watch([sortBy, sortDirection], ([newSortBy, newDirection]) => {
+watch([sortBy, sortDirection, sortMap], ([newSortBy, newDirection, newSortMap]) => {
   emit('update:sortBy', newSortBy);
   emit('update:sortDirection', newDirection);
   emit('sort', {
-    sortBy: newSortBy,
-    direction: newDirection,
+    sortBy: multiSort.value ? Array.from(newSortMap.keys()) : newSortBy,
+    direction: multiSort.value ? Array.from(newSortMap.values()) : newDirection,
   });
 });
 
@@ -473,12 +500,12 @@ const handleRowClick = (item: VDataTableItem, index: number) => {
                   </span>
                   <Icon
                     name="heroicons:chevron-down"
-                    v-if="header.sorting === 'desc'"
+                    v-if="sortMap.get(header.value) === 'desc'"
                     class="v-table-sort-icon"
                   />
                   <Icon
                     name="heroicons:chevron-up"
-                    v-if="header.sorting === 'asc'"
+                    v-if="sortMap.get(header.value) === 'asc'"
                     class="v-table-sort-icon"
                   />
                 </button>


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR added support for multi-column sorting through `multiSort` prop and also fixes issues with header sort state not reflecting current sort state (previous to this PR, the UI gave impression that sort applied is multi column, despite not being so, and the sort direction also not relative to toggled column sort state).

NOTE: If `multiSort` is enabled (default is disabled), values emitted by `sortBy`, `sortDirection` and `sort` event will be sent as array instead of plain string. This is to prevent breaking changes to existing implementation.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
