### PR TITLE
feat(Forms): add `hideError` prop on `VInput` and new `ErrorMessage` component

### DIFF
--- a/packages/forms/src/ErrorMessage.vue
+++ b/packages/forms/src/ErrorMessage.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="v-input-error">
+    <slot />
+  </div>
+</template>

--- a/packages/forms/src/index.ts
+++ b/packages/forms/src/index.ts
@@ -16,6 +16,7 @@ export {default as VInputGroup} from './input/VInputGroup.vue';
 export {default as VInputRange} from './input/VInputRange.vue';
 export {default as VRadio} from './radio/VRadio.vue';
 export {default as VRadioGroup} from './radio/VRadioGroup.vue';
+export {default as VErrorMessage} from './ErrorMessage.vue';
 export * from './composables';
 export * from './form-select/types';
 export * from './file-input/types';

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -8,6 +8,7 @@ export default {
 import {PropType} from 'vue';
 import Icon from '@gits-id/icon';
 import {useFormValue, ValidationMode} from '../composables';
+import ErrorMessage from '../ErrorMessage.vue';
 
 type IconSize = InstanceType<typeof Icon>['$props']['size'];
 
@@ -279,13 +280,9 @@ const {errorMessage, uncontrolledValue, validationListeners, inputId, clear} =
       </slot>
     </div>
 
-    <div
-      v-if="errorMessage && !hideError"
-      class="v-input-error"
-      :class="errorClass"
-    >
+    <ErrorMessage v-if="errorMessage && !hideError" :class="errorClass">
       {{ errorMessage }}
-    </div>
+    </ErrorMessage>
   </div>
 </template>
 

--- a/packages/forms/src/input/VInput.vue
+++ b/packages/forms/src/input/VInput.vue
@@ -160,6 +160,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  hideError: {
+    type: Boolean,
+    default: false,
+  },
 });
 
 const emit = defineEmits([
@@ -275,7 +279,11 @@ const {errorMessage, uncontrolledValue, validationListeners, inputId, clear} =
       </slot>
     </div>
 
-    <div v-if="errorMessage" class="v-input-error" :class="errorClass">
+    <div
+      v-if="errorMessage && !hideError"
+      class="v-input-error"
+      :class="errorClass"
+    >
       {{ errorMessage }}
     </div>
   </div>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- new `hideError` prop on `VInput`
- new `ErrorMessage` component.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
