### PR TITLE
test(VAutoComplete): add unit testing VAutoComplete component

### DIFF
--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -20,6 +20,7 @@
     "@gits-id/icon": "^1.0.0-beta.3",
     "@headlessui/vue": "^1.6.0",
     "tailwindcss": "^3.0.23",
+    "wait-for-expect": "^3.0.2",
     "vue": "^3.2.31"
   },
   "devDependencies": {

--- a/packages/autocomplete/src/VAutocomplete.spec.ts
+++ b/packages/autocomplete/src/VAutocomplete.spec.ts
@@ -1,6 +1,30 @@
-import {mount} from '@vue/test-utils';
-import {describe, expect, test} from 'vitest';
+import {flushPromises, mount} from '@vue/test-utils';
+import {describe, expect, it, test} from 'vitest';
 import VAutocomplete from './VAutocomplete.vue';
+import {ComboboxLabel, ComboboxOption} from '@headlessui/vue';
+import {defineComponent} from 'vue';
+import {useForm} from 'vee-validate';
+import {object} from 'yup';
+import waitForExpect from 'wait-for-expect';
+
+const items = [
+  {
+    text: 'John Doe',
+    value: 'john doe',
+  },
+  {
+    text: 'Jojo',
+    value: 'jojo',
+  },
+  {
+    text: 'Mikael',
+    value: 'mikael',
+  },
+  {
+    text: 'Bosnam',
+    value: 'bosnam',
+  },
+];
 
 describe('VAutocomplete', () => {
   test('mount component', () => {
@@ -14,16 +38,7 @@ describe('VAutocomplete', () => {
         placeholder: 'Search...',
         label: '',
         rules: '',
-        items: [
-          {
-            text: 'Item 1',
-            value: 1,
-          },
-          {
-            text: 'Item 2',
-            value: 2,
-          },
-        ],
+        items: [],
         noDataText: 'No data.',
         notFoundText: 'Nothing found.',
         clearable: false,
@@ -31,7 +46,227 @@ describe('VAutocomplete', () => {
     });
 
     expect(wrapper.html()).toContain('Search...');
-    expect(wrapper.find('input').exists()).toBe(true);
-    wrapper.find('input').setValue('ite');
+    expect(wrapper.find('input').exists()).toBeTruthy();
+  });
+
+  describe('when typing an input', () => {
+    it('show list filtered', async () => {
+      const wrapper = mount(VAutocomplete, {
+        props: {
+          modelValue: undefined,
+          searchBy: 'text',
+          displayText: 'text',
+          placeholder: 'Search...',
+          label: '',
+          rules: '',
+          items,
+          noDataText: 'No data.',
+          notFoundText: 'Nothing found.',
+          clearable: false,
+        },
+      });
+
+      await wrapper.find('input').setValue('jo');
+
+      const autocompleteItems = wrapper.findAll('li.autocomplete-item');
+
+      expect(autocompleteItems.length).toEqual(2);
+    });
+
+    it.skip('show all items when no character on input', async () => {
+      // on ui testing there is no error
+      const wrapper = mount(VAutocomplete, {
+        props: {
+          modelValue: 'jo',
+          searchBy: 'text',
+          displayText: 'text',
+          placeholder: 'Search...',
+          label: '',
+          rules: '',
+          items,
+          noDataText: 'No data.',
+          notFoundText: 'Nothing found.',
+          clearable: false,
+        },
+      });
+
+      await wrapper.find('input').setValue('');
+
+      const autocompleteItems = wrapper.findAll('li.autocomplete-item');
+
+      expect(autocompleteItems.length).toEqual(4);
+    });
+  });
+
+  describe('when one of list clicked', () => {
+    it('is item selected', async () => {
+      const wrapper = mount(VAutocomplete, {
+        props: {
+          searchBy: 'text',
+          displayText: 'text',
+          placeholder: 'Search...',
+          items,
+        },
+      });
+
+      await wrapper.find('input').setValue('jo');
+      const options = wrapper.findAllComponents(ComboboxOption);
+      await options[0].trigger('click');
+
+      expect(options[0].html()).toContain('autocomplete-item-text--selected');
+
+      await options[1].trigger('click');
+
+      expect(options[0].html()).not.toContain(
+        'autocomplete-item-text--selected',
+      );
+      expect(options[1].html()).toContain('autocomplete-item-text--selected');
+    });
+  });
+
+  describe('when clearable is true', () => {
+    it('button to clear is appear on selected', async () => {
+      const wrapper = mount(VAutocomplete, {
+        props: {
+          searchBy: 'text',
+          displayText: 'text',
+          placeholder: 'Search...',
+          items,
+          clearable: true,
+        },
+      });
+
+      await wrapper.find('input').setValue('jo');
+      const options = wrapper.findAllComponents(ComboboxOption);
+      await options[0].trigger('click');
+
+      expect(options[0].html()).toContain('autocomplete-item-text--selected');
+
+      const clearButton = wrapper.find('.autocomplete-clearable-button');
+
+      expect(clearButton).toBeTruthy();
+    });
+
+    describe.skip('and when the clear button clicked', () => {
+      it('remove selected', async () => {
+        const wrapper = mount(VAutocomplete, {
+          attachTo: document.body,
+          props: {
+            modelValue: 'john doe',
+            searchBy: 'text',
+            displayText: 'text',
+            placeholder: 'Search...',
+            items,
+            clearable: true,
+          },
+        });
+
+        await wrapper.find('input').setValue('jo');
+        const options = wrapper.findAllComponents(ComboboxOption);
+
+        await options[0].trigger('click');
+
+        const clearButton = wrapper.find(
+          'button.autocomplete-clearable-button',
+        );
+
+        await clearButton.trigger('click');
+
+        expect(options[0].html()).not.toContain(
+          'autocomplete-item-text--selected',
+        );
+      });
+    });
+
+    describe('when label provided', () => {
+      it('render label', () => {
+        const wrapper = mount(VAutocomplete, {
+          props: {
+            searchBy: 'text',
+            displayText: 'text',
+            placeholder: 'Search...',
+            items,
+            label: 'Label test',
+          },
+        });
+
+        const label = wrapper.findComponent(ComboboxLabel);
+
+        expect(wrapper.html()).toContain('autocomplete-label');
+        expect(label).toBeTruthy();
+        expect(label.html()).toContain('Label test');
+      });
+    });
+
+    describe('when searched empty', () => {
+      it('show no data text', async () => {
+        const wrapper = mount(VAutocomplete, {
+          props: {
+            searchBy: 'text',
+            displayText: 'text',
+            placeholder: 'Search...',
+            items,
+            label: 'Label test',
+            noDataText: 'Data tidak ditemukan',
+          },
+        });
+
+        await wrapper.find('input').setValue('za');
+
+        expect(wrapper.html()).toContain('autocomplete-empty');
+        expect(wrapper.find('.autocomplete-empty').text()).toContain(
+          wrapper.vm.noDataText,
+        );
+      });
+    });
+
+    describe('when use with validation', () => {
+      it('can show error message when error appear', async () => {
+        const WrapperComponent = defineComponent({
+          components: {
+            VAutocomplete,
+          },
+          setup() {
+            const schema = object({
+              test: object().required().label('Test'),
+            });
+
+            const {handleSubmit} = useForm({
+              validationSchema: schema,
+            });
+
+            const onSubmit = handleSubmit((values) => {
+              alert(JSON.stringify(values));
+            });
+            return {
+              onSubmit,
+            };
+          },
+          template: `<form @submit="onSubmit" class="border-none">
+            <VAutocomplete
+              name="test"
+              label="Test"
+              placeholder="Choose name"
+              :items="items"
+            />
+            <div class="mt-4">
+              <button type="submit">Submit</button>
+            </div>
+          </form>`,
+        });
+
+        const wrapper = mount(WrapperComponent);
+
+        await wrapper.find('form').trigger('submit');
+
+        await flushPromises();
+        await waitForExpect(() => {
+          expect(wrapper.html()).toContain('autocomplete-error');
+          expect(wrapper.find('.autocomplete-error').text()).toContain(
+            'Test is a required field',
+          );
+        });
+      });
+    });
   });
 });

--- a/packages/autocomplete/src/VAutocomplete.vue
+++ b/packages/autocomplete/src/VAutocomplete.vue
@@ -48,7 +48,6 @@ const props = withDefaults(defineProps<Props>(), {
   name: '',
   items: () => [],
   noDataText: 'No data.',
-  notFoundText: 'Nothing found.',
   clearable: false,
   errorClass: 'autocomplete-error',
   wrapperClass: '',
@@ -152,10 +151,7 @@ const clear = () => {
         @after-leave="query = ''"
       >
         <ComboboxOptions class="autocomplete-options">
-          <div
-            v-if="filteredItems.length === 0 && query === ''"
-            class="autocomplete-empty"
-          >
+          <div v-if="filteredItems.length === 0" class="autocomplete-empty">
             {{ noDataText }}
           </div>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20612,6 +20612,11 @@ vuex@^4.0.2:
   dependencies:
     "@vue/devtools-api" "^6.0.0-beta.11"
 
+wait-for-expect@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/wait-for-expect/-/wait-for-expect-3.0.2.tgz#d2f14b2f7b778c9b82144109c8fa89ceaadaa463"
+  integrity sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==
+
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/walker/-/walker-1.0.8.tgz#bd498db477afe573dc04185f011d3ab8a8d7653f"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
![image](https://user-images.githubusercontent.com/59602236/224222671-1195a166-1aa8-4710-bd1d-9a803880c2ca.png)

Minta Validasi : 
- ( notFoundText ) keliatannya props ini ga kepake, karena udah ada noDataText
- Sekarang kalau misal search dan ga nemu apa yang di search, itu ga nampilin apa apa. Ada kondisi ketika filteredItems nya 0 dan variable query nya kosong, maka dia nampilin noDataText nya. 
![no data - autocomplete](https://user-images.githubusercontent.com/59602236/224223444-5782380b-014d-4d1c-85f6-f98918b74103.png)
Butuh konfirmasi apakaha memang seperti kondisinya ? Di commitan saya ini, aku ada ngehapus kondisi `&& query === ''` nya. Agar ketika search dan ga nemuin yang dicari, harusnya `noDataText` nya muncul. Ini harusnya ke fix di sini : https://github.com/gitsindonesia/ui-component/commit/f1530ec12357122a1e20db6892dd946860e4ef09

- Lalu ada beberapa test yang aku skip : 
1. Ketika `query` nya kosong, itu nampilin semua items. Tapi ketika di write codingannya. Ternyata muncul error
![Screenshot 2023-03-10 113419](https://user-images.githubusercontent.com/59602236/224224348-de14a512-6e2c-408e-9aa1-6fc5d76d2e8f.png) Dan ini kayanya karena bawaan plugin. Tapi kalau dari ui testing nya sih aman.

2. Ketika `clearable true` terus muncul button untuk ngeclear. Ketika button ditrigger harusnya itu ngetrigger function `clear()` yang ada dicomponent. Tapi ga tau kenapa, ga ketrigger. Test nya success tapi expected nya karena ga ketrigger tadi jadinya ga sesuai.

3. Add plugin `wait-for-expect` to testing error validation vee validate

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
