### PR TITLE
feat(Modal): add new declarative modal components

### DIFF
--- a/docs/components/modal.md
+++ b/docs/components/modal.md
@@ -317,6 +317,78 @@ We can also customize modal via CSS Properties.
 
 </LivePreview>
 
+### Declarative Modal
+
+Starting from version `v1.0.0-beta.11`, we have introduced a new declarative approach to use the modal component, providing you with enhanced flexibility. This approach involves breaking down the modal component into five separate components, each serving a specific purpose. To utilize this feature, you will need to manually import these components.
+
+#### Component List
+
+The modal components are as follows:
+
+- `Modal`
+-   `ModalHeader`
+-   `ModalTitle`
+-   `ModalBody`
+-   `ModalFooter`
+
+### Usage
+
+Unlike before, these components are not auto-imported. Therefore, you must import them individually based on your requirements.
+
+Here's a brief overview of each modal component and its purpose:
+
+- `Modal`: This is the main component that serves as the container for the entire modal dialog.
+- `ModalHeader`: Use this component to display the header section of the modal. Typically, it contains the title and close button.
+- `ModalTitle`: This component is used to display the title of the modal. It is usually placed inside the `ModalHeader`.
+- `ModalBody`: This component allows you to add content to the body of the modal. Any information or forms you wish to present should be placed within this component.
+- `ModalFooter`: The footer component is utilized to include any additional elements at the bottom of the modal, such as action buttons (e.g., Save, Cancel).
+
+#### Example
+
+<LivePreview src="components-modal--declarative" >
+
+```vue
+<script setup lang="ts">
+import {
+  VBtn,
+  Modal,
+  ModalHeader,
+  ModalTitle,
+  ModalFooter,
+  ModalBody,
+} from '@morpheme/ui';
+
+const isOpen = ref(false);
+</script>
+
+<template>
+  <VBtn @click="isOpen = true">Open Modal</VBtn>
+
+  <Modal v-model="isOpen" v-bind="params">
+    <ModalHeader>
+      <ModalTitle>Modal Title</ModalTitle>
+      <VBtn
+        @click="isOpen = false"
+        prefix-icon="ri:close-line"
+        size="sm"
+        text
+        icon
+        fab
+      />
+    </ModalHeader>
+    <ModalBody>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+    </ModalBody>
+    <ModalFooter>
+      <VBtn @click="isOpen = false">Close</VBtn>
+      <VBtn @click="isOpen = false" color="primary">Okay</VBtn>
+    </ModalFooter>
+  </Modal>
+</template>
+```
+
+</LivePreview>
+
 ## Props
 
 | Name                            | Type      | Default          |

--- a/docs/guide/customization.md
+++ b/docs/guide/customization.md
@@ -64,3 +64,40 @@ module.exports = {
   presets: [require('./src/preset')],
 };
 ```
+
+## Customize Component with Tailwind Arbitrary Values and CSS Properties
+
+You'll be delighted to discover that you can use Tailwind arbitrary values and CSS properties to customize the appearance of not only your modal component but also other components within your Vue applications. Tailwind CSS makes it a breeze to create stylish and unique designs for various components. Let's see how it's done:
+
+```vue
+<template>
+  <VModal
+    model-value
+    title="Modal Title"
+    class="
+      [--v-modal-bg-color:var(--color-primary-600)]
+      [--v-modal-title-color:var(--color-yellow-300)]
+      [--v-modal-text-color:var(--color-white)]
+      [--btn-text-color:var(--color-white)]
+    "
+  >
+    Hello Tailwind!
+  </VModal>
+
+  <VCard
+    class="
+      [--card-bg-color:var(--color-gray-200)]
+      [--card-color:var(--color-gray-800)]
+    "
+  >
+    <h2>Card Content</h2>
+    <p>Some text in the card.</p>
+  </VCard>
+</template>
+```
+
+In the code above, we have a Vue component that includes a `<VModal>` component and another component called `<VCard>`. Both components can be customized using Tailwind arbitrary values and CSS properties applied directly to their respective class attributes.
+
+Custom CSS properties are defined using double hyphens (e.g., `--v-modal-bg-color`, `--v-modal-title-color`, etc.). The values of these custom CSS properties are set to Tailwind CSS color variables (e.g., `--color-primary-600`, `--color-yellow-300`, etc.).
+
+With this setup, you have the flexibility to modify the appearance of various components within your Vue application, creating a consistent and harmonious design across all elements.

--- a/packages/modal/src/Modal.vue
+++ b/packages/modal/src/Modal.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
-import {useVModel} from '@vueuse/core';
 import {
   Dialog,
   DialogPanel,
   TransitionRoot,
   TransitionChild,
 } from '@headlessui/vue';
+import {ref, watch} from 'vue';
 
 interface Props {
   modelValue?: boolean;
@@ -23,16 +23,45 @@ const props = withDefaults(defineProps<Props>(), {
 const emit =
   defineEmits<{
     (e: 'update:modelValue', value: boolean): void;
+    (e: 'close'): void;
+    (e: 'open'): void;
   }>();
 
-const isOpen = useVModel(props, 'modelValue', emit);
+const isOpen = ref(props.modelValue);
+
+watch(
+  () => props.modelValue,
+  (val) => (isOpen.value = val),
+);
+watch(isOpen, (val) => emit('update:modelValue', val));
+
+function onModalClose() {
+  if (props.persistent || props.loading) {
+    return null;
+  } else {
+    closeModal();
+  }
+}
+
+function closeModal() {
+  isOpen.value = false;
+  emit('update:modelValue', false);
+  emit('close');
+}
+
+function openModal() {
+  isOpen.value = true;
+  emit('update:modelValue', true);
+  emit('open');
+}
 </script>
 
 <template>
+  <slot name="activator" :open="openModal" />
   <TransitionRoot appear :show="isOpen" as="template">
     <Dialog
       :open="isOpen"
-      @close="isOpen = false"
+      static
       as="div"
       class="v-modal"
       :class="[
@@ -43,26 +72,47 @@ const isOpen = useVModel(props, 'modelValue', emit);
           'v-modal--persistent': persistent,
         },
       ]"
+      @close="onModalClose"
+      v-bind="$attrs"
     >
       <div class="v-modal-dialog">
         <div class="v-modal-content">
-          <transition name="fade">
-            <div
-              v-if="!fullscreen && isOpen"
-              class="v-modal-overlay"
-              :class="{
-                'v-modal-overlay--blur': overlayBlur,
-              }"
-            />
-          </transition>
+          <TransitionChild
+            as="template"
+            enter="v-modal-overlay-transition-enter-active"
+            enter-from="v-modal-overlay-transition-enter-from"
+            enter-to="v-modal-overlay-transition-enter-to"
+            leave="v-modal-overlay-transition-leave-active"
+            leave-from="v-modal-overlay-transition-leave-from"
+            leave-to="v-modal-overlay-transition-leave-to"
+          >
+            <slot name="overlay">
+              <div
+                class="v-modal-overlay"
+                :class="{
+                  'v-modal-overlay--blur': overlayBlur,
+                }"
+              />
+            </slot>
+          </TransitionChild>
 
           <span v-if="!fullscreen" class="v-modal-spacer" aria-hidden="true">
             &#8203;
           </span>
 
-          <DialogPanel class="v-modal-panel">
-            <slot />
-          </DialogPanel>
+          <TransitionChild
+            as="template"
+            enter="v-modal-transition-enter-active"
+            enter-from="v-modal-transition-enter-from"
+            enter-to="v-modal-transition-enter-to"
+            leave="v-modal-transition-leave-active"
+            leave-from="v-modal-transition-leave-from"
+            leave-to="v-modal-transition-leave-to"
+          >
+            <DialogPanel class="v-modal-panel">
+              <slot />
+            </DialogPanel>
+          </TransitionChild>
         </div>
       </div>
     </Dialog>

--- a/packages/modal/src/Modal.vue
+++ b/packages/modal/src/Modal.vue
@@ -14,7 +14,14 @@ interface Props {
   loading?: boolean;
   persistent?: boolean;
   overlayBlur?: boolean;
+  hideOverlay?: boolean;
+  width?: string;
+  maxWidth?: string;
 }
+
+defineOptions({
+  inheritAttrs: false,
+});
 
 const props = withDefaults(defineProps<Props>(), {
   modelValue: false,
@@ -73,12 +80,11 @@ function openModal() {
         },
       ]"
       @close="onModalClose"
-      v-bind="$attrs"
     >
       <div class="v-modal-dialog">
         <div class="v-modal-content">
           <TransitionChild
-            as="template"
+            as="div"
             enter="v-modal-overlay-transition-enter-active"
             enter-from="v-modal-overlay-transition-enter-from"
             enter-to="v-modal-overlay-transition-enter-to"
@@ -86,8 +92,9 @@ function openModal() {
             leave-from="v-modal-overlay-transition-leave-from"
             leave-to="v-modal-overlay-transition-leave-to"
           >
-            <slot name="overlay">
+            <slot name="overlay" v-bind="{hideOverlay, overlayBlur}">
               <div
+                v-if="!hideOverlay"
                 class="v-modal-overlay"
                 :class="{
                   'v-modal-overlay--blur': overlayBlur,
@@ -109,7 +116,11 @@ function openModal() {
             leave-from="v-modal-transition-leave-from"
             leave-to="v-modal-transition-leave-to"
           >
-            <DialogPanel class="v-modal-panel">
+            <DialogPanel
+              class="v-modal-panel"
+              :style="{width, maxWidth}"
+              v-bind="$attrs"
+            >
               <slot />
             </DialogPanel>
           </TransitionChild>

--- a/packages/modal/src/Modal.vue
+++ b/packages/modal/src/Modal.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import {useVModel} from '@vueuse/core';
+import {
+  Dialog,
+  DialogPanel,
+  TransitionRoot,
+  TransitionChild,
+} from '@headlessui/vue';
+
+interface Props {
+  modelValue?: boolean;
+  centered?: boolean;
+  fullscreen?: boolean;
+  loading?: boolean;
+  persistent?: boolean;
+  overlayBlur?: boolean;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  modelValue: false,
+});
+
+const emit =
+  defineEmits<{
+    (e: 'update:modelValue', value: boolean): void;
+  }>();
+
+const isOpen = useVModel(props, 'modelValue', emit);
+</script>
+
+<template>
+  <TransitionRoot appear :show="isOpen" as="template">
+    <Dialog
+      :open="isOpen"
+      @close="isOpen = false"
+      as="div"
+      class="v-modal"
+      :class="[
+        {
+          'v-modal--centered': centered,
+          'v-modal--fullscreen': fullscreen,
+          'v-modal--loading': loading,
+          'v-modal--persistent': persistent,
+        },
+      ]"
+    >
+      <div class="v-modal-dialog">
+        <div class="v-modal-content">
+          <transition name="fade">
+            <div
+              v-if="!fullscreen && isOpen"
+              class="v-modal-overlay"
+              :class="{
+                'v-modal-overlay--blur': overlayBlur,
+              }"
+            />
+          </transition>
+
+          <span v-if="!fullscreen" class="v-modal-spacer" aria-hidden="true">
+            &#8203;
+          </span>
+
+          <DialogPanel class="v-modal-panel">
+            <slot />
+          </DialogPanel>
+        </div>
+      </div>
+    </Dialog>
+  </TransitionRoot>
+</template>

--- a/packages/modal/src/ModalBody.vue
+++ b/packages/modal/src/ModalBody.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="v-modal-body">
+    <slot />
+  </div>
+</template>

--- a/packages/modal/src/ModalFooter.vue
+++ b/packages/modal/src/ModalFooter.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="v-modal-footer">
+    <slot />
+  </div>
+</template>

--- a/packages/modal/src/ModalHeader.vue
+++ b/packages/modal/src/ModalHeader.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import {DialogTitle} from '@headlessui/vue';
+</script>
+
+<template>
+  <DialogTitle as="div" class="v-modal-header">
+    <slot />
+  </DialogTitle>
+</template>

--- a/packages/modal/src/ModalTitle.vue
+++ b/packages/modal/src/ModalTitle.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="v-modal-title">
+    <slot />
+  </div>
+</template>

--- a/packages/modal/src/VModal.stories.ts
+++ b/packages/modal/src/VModal.stories.ts
@@ -2,9 +2,10 @@ import { VCard } from '@morpheme/card';
 import {Meta, Story} from '@storybook/vue3';
 import VModal from './VModal.vue';
 import vueRouter from 'storybook-vue3-router';
-import {ref} from 'vue';
+import {reactive, ref} from 'vue';
 import VBtn from '@morpheme/button';
 import {VModalEvent} from './types';
+import Modal from './Modal.vue';
 
 export default {
   title: 'Components/Modal',
@@ -366,5 +367,24 @@ export const DarkMode: Story = (args) => ({
       </VCard>
     </VModal>
   </div>
+  `,
+});
+
+export const Declarative: Story = (args) => ({
+  components: {Modal, VBtn},
+  setup() {
+    const isOpen = ref(false)
+    const params = reactive({
+      fullscreen: false,
+    })
+    return {args, isOpen, params};
+  },
+  template: `
+  <VBtn @click="isOpen = true">Open Modal</VBtn>
+
+  <Modal v-model="isOpen" v-bind="params">
+    <p>Hello</p>
+    <VBtn @click="params.fullscreen = !params.fullscreen">Fullscreen</VBtn>
+  </Modal>
   `,
 });

--- a/packages/modal/src/VModal.stories.ts
+++ b/packages/modal/src/VModal.stories.ts
@@ -1,11 +1,15 @@
-import { VCard } from '@morpheme/card';
+import {VCard} from '@morpheme/card';
 import {Meta, Story} from '@storybook/vue3';
 import VModal from './VModal.vue';
 import vueRouter from 'storybook-vue3-router';
-import {reactive, ref} from 'vue';
-import VBtn from '@morpheme/button';
+import {onUnmounted, ref} from 'vue';
+import {VBtn} from '@morpheme/button';
 import {VModalEvent} from './types';
 import Modal from './Modal.vue';
+import ModalHeader from './ModalHeader.vue';
+import ModalTitle from './ModalTitle.vue';
+import ModalBody from './ModalBody.vue';
+import ModalFooter from './ModalFooter.vue';
 
 export default {
   title: 'Components/Modal',
@@ -14,24 +18,18 @@ export default {
   args: {
     modelValue: true,
     title: 'Modal Header',
-    confirm: false,
-    confirmColor: 'primary',
-    confirmProps: {},
-    confirmText: 'Confirm',
-    closeText: 'Close',
-    closeProps: {},
-    headerClass: '',
-    bodyClass: '',
-    footerClass: '',
-    modalClass: '',
-    boolean: false,
-    hideHeader: false,
-    hideFooter: false,
     onConfirm: (e: VModalEvent) => {
       alert('Confirmed!');
       e.close();
     },
   },
+  subcomponents:{
+    Modal,
+    ModalHeader,
+    ModalTitle,
+    ModalBody,
+    ModalFooter,
+  }
 } as Meta;
 
 const Template: Story = (args) => ({
@@ -44,12 +42,12 @@ const Template: Story = (args) => ({
     return {args, isOpen};
   },
   template: `
-<v-modal v-bind="args" v-model="isOpen" v-bind="args">
+<v-modal v-bind="args" v-model="isOpen">
   <template #activator="{open}">
     <v-btn @click="open">Click Me</v-btn>
   </template>
   Hello World
-</v-modal>  
+</v-modal>
   `,
 });
 
@@ -356,7 +354,18 @@ export const Customization: Story = (args) => ({
 export const DarkMode: Story = (args) => ({
   components: {VModal, VCard},
   setup() {
-    document.documentElement.classList.add('dark', 'dark:bg-gray-true-900', 'dark:text-gray-true-200');
+    document.documentElement.classList.add(
+      'dark',
+      'dark:bg-gray-true-900',
+      'dark:text-gray-true-200',
+    );
+    onUnmounted(() => {
+      document.documentElement.classList.remove(
+        'dark',
+        'dark:bg-gray-true-900',
+        'dark:text-gray-true-200',
+      );
+    });
     return {args};
   },
   template: `
@@ -371,20 +380,40 @@ export const DarkMode: Story = (args) => ({
 });
 
 export const Declarative: Story = (args) => ({
-  components: {Modal, VBtn},
+  components: {
+    Modal,
+    VBtn,
+    ModalHeader,
+    ModalTitle,
+    ModalFooter,
+    ModalBody,
+  },
   setup() {
-    const isOpen = ref(false)
-    const params = reactive({
-      fullscreen: false,
-    })
-    return {args, isOpen, params};
+    const isOpen = ref(false);
+    return {args, isOpen};
   },
   template: `
   <VBtn @click="isOpen = true">Open Modal</VBtn>
 
   <Modal v-model="isOpen" v-bind="params">
-    <p>Hello</p>
-    <VBtn @click="params.fullscreen = !params.fullscreen">Fullscreen</VBtn>
+    <ModalHeader>
+      <ModalTitle>Modal Title</ModalTitle>
+      <VBtn
+        @click="isOpen = false"
+        prefix-icon="ri:close-line"
+        size="sm"
+        text
+        icon
+        fab
+      />
+    </ModalHeader>
+    <ModalBody>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
+    </ModalBody>
+    <ModalFooter>
+      <VBtn @click="isOpen = false">Close</VBtn>
+      <VBtn @click="isOpen = false" color="primary">Okay</VBtn>
+    </ModalFooter>
   </Modal>
   `,
 });

--- a/packages/modal/src/VModal.stories.ts
+++ b/packages/modal/src/VModal.stories.ts
@@ -379,7 +379,7 @@ export const DarkMode: Story = (args) => ({
   `,
 });
 
-export const Declarative: Story = (args) => ({
+export const Declarative: Story<typeof Modal> = (args) => ({
   components: {
     Modal,
     VBtn,
@@ -395,7 +395,10 @@ export const Declarative: Story = (args) => ({
   template: `
   <VBtn @click="isOpen = true">Open Modal</VBtn>
 
-  <Modal v-model="isOpen" v-bind="params">
+  <Modal
+    v-bind="args"
+    v-model="isOpen"
+  >
     <ModalHeader>
       <ModalTitle>Modal Title</ModalTitle>
       <VBtn

--- a/packages/modal/src/VModal.stories.ts
+++ b/packages/modal/src/VModal.stories.ts
@@ -351,6 +351,27 @@ export const Customization: Story = (args) => ({
   `,
 });
 
+export const Tailwind: Story = (args) => ({
+  components: {VModal, VCard},
+  setup() {
+    return {args};
+  },
+  template: `
+  <VModal
+    model-value
+    title="Modal Title"
+    class="
+      [--v-modal-bg-color:var(--color-primary-600)]
+      [--v-modal-title-color:var(--color-yellow-300)]
+      [--v-modal-text-color:var(--color-white)]
+      [--btn-text-color:var(--color-white)]
+    "
+  >
+    Hello Tailwind!
+  </VModal>
+  `,
+});
+
 export const DarkMode: Story = (args) => ({
   components: {VModal, VCard},
   setup() {

--- a/packages/modal/src/VModal.vue
+++ b/packages/modal/src/VModal.vue
@@ -416,12 +416,12 @@ const panelStyles = computed(() => {
         <div class="v-modal-content">
           <TransitionChild
             as="template"
-            enter="duration-300 ease-out"
-            enter-from="opacity-0"
-            enter-to="opacity-100"
-            leave="duration-200 ease-in"
-            leave-from="opacity-100"
-            leave-to="opacity-0"
+            enter="v-modal-overlay-transition-enter-active"
+            enter-from="v-modal-overlay-transition-enter-from"
+            enter-to="v-modal-overlay-transition-enter-to"
+            leave="v-modal-overlay-transition-leave-active"
+            leave-from="v-modal-overlay-transition-leave-from"
+            leave-to="v-modal-overlay-transition-leave-to"
           >
             <slot name="overlay">
               <div
@@ -439,12 +439,12 @@ const panelStyles = computed(() => {
 
           <TransitionChild
             as="template"
-            enter="duration-300 ease-out"
-            enter-from="opacity-0 scale-95"
-            enter-to="opacity-100 scale-100"
-            leave="duration-200 ease-in"
-            leave-from="opacity-100 scale-100"
-            leave-to="opacity-0 scale-95"
+            enter="v-modal-transition-enter-active"
+            enter-from="v-modal-transition-enter-from"
+            enter-to="v-modal-transition-enter-to"
+            leave="v-modal-transition-leave-active"
+            leave-from="v-modal-transition-leave-from"
+            leave-to="v-modal-transition-leave-to"
           >
             <DialogPanel
               class="v-modal-panel"

--- a/packages/modal/src/index.ts
+++ b/packages/modal/src/index.ts
@@ -1,6 +1,10 @@
-import VModal from './VModal.vue';
 import './VModal.dark.scss';
 
+export {default} from './VModal.vue';
+export {default as VModal} from './VModal.vue';
+export {default as Modal} from './Modal.vue';
+export {default as ModalBody} from './ModalBody.vue';
+export {default as ModalFooter} from './ModalFooter.vue';
+export {default as ModalHeader} from './ModalHeader.vue';
+export {default as ModalTitle} from './ModalTitle.vue';
 export * from './types';
-export {VModal};
-export default VModal;

--- a/packages/themes/src/morpheme/_modal.scss
+++ b/packages/themes/src/morpheme/_modal.scss
@@ -153,4 +153,37 @@
   &--centered &-footer {
     justify-content: center;
   }
+
+  &-transition {
+    &-enter-active {
+      transition: all 300ms ease-out;
+    }
+    &-leave-active {
+      transition: all 200ms ease-in;
+    }
+    &-enter-from,
+    &-leave-to {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+    &-enter-to,
+    &-leave-from {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
+
+  &-overlay-transition {
+    &-enter-active {
+      transition: all 300ms ease-out;
+    }
+    &-leave-active {
+      transition: all 200ms ease-in;
+    }
+
+    &-enter-from,
+    &-leave-to {
+      opacity: 0;
+    }
+  }
 }

--- a/packages/themes/src/morpheme/_modal.scss
+++ b/packages/themes/src/morpheme/_modal.scss
@@ -18,6 +18,7 @@
   --v-modal-margin-padding-x: var(--size-spacing-4);
   --v-modal-margin-padding-y: var(--size-spacing-4);
   --v-modal-content-text-align: center;
+  --v-modal-panel-text-align: left;
 
   /* title */
   --v-modal-title-font-weight: var(--font-weight-semibold);

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -314,7 +314,7 @@ export * from '@morpheme/dropdown/src/types';
 export * from '@morpheme/forms/src/input/types';
 export * from '@morpheme/navbar/src/types';
 export * from '@morpheme/tabs/src/types';
-export * from '@morpheme/modal/src/types';
+export * from '@morpheme/modal';
 export * from '@morpheme/dropdown/src/types';
 export * from '@morpheme/bottom-sheet/src/types';
 export * from './component-resolver';


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR introduced a new declarative approach to use the modal component, providing you with enhanced flexibility. This approach involves breaking down the modal component into five separate components, each serving a specific purpose. To utilize this feature, you will need to manually import these components.

#### Component List

The modal components are as follows:

- `Modal`
-   `ModalHeader`
-   `ModalTitle`
-   `ModalBody`
-   `ModalFooter`

### Usage

Unlike before, these components are not auto-imported. Therefore, you must import them individually based on your requirements.

Here's a brief overview of each modal component and its purpose:

- `Modal`: This is the main component that serves as the container for the entire modal dialog.
- `ModalHeader`: Use this component to display the header section of the modal. Typically, it contains the title and close button.
- `ModalTitle`: This component is used to display the title of the modal. It is usually placed inside the `ModalHeader`.
- `ModalBody`: This component allows you to add content to the body of the modal. Any information or forms you wish to present should be placed within this component.
- `ModalFooter`: The footer component is utilized to include any additional elements at the bottom of the modal, such as action buttons (e.g., Save, Cancel).

#### Example

```vue
<script setup lang="ts">
import {
  VBtn,
  Modal,
  ModalHeader,
  ModalTitle,
  ModalFooter,
  ModalBody,
} from '@morpheme/ui';

const isOpen = ref(false);
</script>

<template>
  <VBtn @click="isOpen = true">Open Modal</VBtn>

  <Modal v-model="isOpen" v-bind="params">
    <ModalHeader>
      <ModalTitle>Modal Title</ModalTitle>
      <VBtn
        @click="isOpen = false"
        prefix-icon="ri:close-line"
        size="sm"
        text
        icon
        fab
      />
    </ModalHeader>
    <ModalBody>
      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit</p>
    </ModalBody>
    <ModalFooter>
      <VBtn @click="isOpen = false">Close</VBtn>
      <VBtn @click="isOpen = false" color="primary">Okay</VBtn>
    </ModalFooter>
  </Modal>
</template>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
