### PR TITLE
fix(Select): change headless UI usage to `Combobox` component & fix issue can't space when `searchable`

### DIFF
--- a/packages/select/src/VSelect.vue
+++ b/packages/select/src/VSelect.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import {computed, PropType, ref, toRefs, watch} from 'vue';
 import {
-  Listbox,
-  ListboxButton,
-  ListboxOptions,
-  ListboxOption,
-  ListboxLabel,
+  Combobox,
+  ComboboxButton,
+  ComboboxOptions,
+  ComboboxOption,
+  ComboboxLabel,
 } from '@headlessui/vue';
 import VTooltip from '@morpheme/tooltip';
 import {FieldOptions} from 'vee-validate';
@@ -289,12 +289,12 @@ defineSlots<{
       wrapperClass,
     ]"
   >
-    <Listbox v-model="uncontrolledValue">
-      <ListboxLabel v-if="label" class="v-select-label" :class="labelClass">
+    <Combobox v-model="uncontrolledValue">
+      <ComboboxLabel v-if="label" class="v-select-label" :class="labelClass">
         {{ label }}
-      </ListboxLabel>
+      </ComboboxLabel>
       <div class="v-select-panel">
-        <ListboxButton
+        <ComboboxButton
           class="v-select-button"
           :class="[btnClass]"
           :disabled="disabled"
@@ -332,10 +332,10 @@ defineSlots<{
             class="v-select-icon"
             aria-hidden="true"
           />
-        </ListboxButton>
+        </ComboboxButton>
 
         <transition :name="transition">
-          <ListboxOptions
+          <ComboboxOptions
             class="v-select-options"
             :class="{
               'bottom-10': top,
@@ -350,6 +350,13 @@ defineSlots<{
                 clearable
                 v-bind="searchProps"
               />
+              <!--
+              <ComboboxInput
+                :placeholder="searchPlaceholder"
+                @change="search = $event.target.value"
+                v-bind="searchProps"
+              />
+              -->
             </div>
             <div
               v-if="searchable && !filteredItems.length"
@@ -357,7 +364,7 @@ defineSlots<{
             >
               <slot name="empty"> No results</slot>
             </div>
-            <ListboxOption
+            <ComboboxOption
               v-for="(item, index) in filteredItems"
               v-slot="{selected, active}"
               :key="index"
@@ -395,11 +402,11 @@ defineSlots<{
                   </slot>
                 </span>
               </li>
-            </ListboxOption>
-          </ListboxOptions>
+            </ComboboxOption>
+          </ComboboxOptions>
         </transition>
       </div>
-    </Listbox>
+    </Combobox>
     <p v-if="hint" class="v-select-hint">
       <slot name="hint">
         {{ hint }}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the contribution docs before creating a pull request
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

- Change headless UI usage to `Combobox` component
- Fix issue can't space when `searchable`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
